### PR TITLE
説明の詳細

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 脆弱性体験ハンズオン用の「とても脆弱なECサイト」です。**本番利用厳禁**。
 
+## 構成
+
+- Shop（脆弱EC）: Express + EJS + SQLite。学習用の脆弱性（XSS / SQLi / CSRF / 改ざん）を含みます。
+- Attacker（攻撃者サイト）: CSRF体験用の罠サイト。Shopに対してコメント投稿や購入リクエストを送信します。
+
 ## 必要なもの
 
 - Docker（Desktop等）
@@ -22,12 +27,41 @@ docker compose up
 - Shop（脆弱EC）: `http://localhost:8000`
 - Attacker（攻撃者サイト）: `http://localhost:9000`
 
+停止する場合は別ターミナルで `docker compose down` を実行してください。
+
+## 初期データ
+
+起動時にテーブルを作り直すため、**ユーザー/コメント/注文は毎回初期化**されます。
+
+- ユーザー: `alice / password123`, `bob / password123`
+- 商品: Coffee Beans / Drip Bag / Mug Cup
+
+## 環境変数（任意）
+
+### Shop
+
+- `PORT`（既定: 8000）
+- `SESSION_SECRET`（既定: dev-secret）
+- `DATABASE_PATH`（既定: `/data/shop.db`）
+- `ATTACKER_URL`（既定: `http://localhost:9000`。Hands-onページのリンク先に利用）
+
+### Attacker
+
+- `PORT`（既定: 9000）
+- `TARGET_BASE`（既定: `http://localhost:8000`。攻撃対象のShop URL）
+
 ## 体験に使う導線（概要）
 
-- **XSS**: 商品詳細の「コメント投稿」→ コメントが無エスケープで表示される
-- **SQL Injection**: 「商品検索」→ 文字列結合SQL
-- **フォーム値改ざん**: 「購入」フォームの `hidden` 値（unit/total）を改ざん
-- **CSRF**: Attackerサイトから Shop の購入を“勝手に”実行
+- **XSS**:
+  - `/search` の検索語が無エスケープで反映（反射型）
+  - `/products/:id` のコメントが無エスケープで表示（保存型）
+- **SQL Injection**:
+  - `/login` のユーザー名/パスワードが文字列結合SQL
+  - `/search` の `q` が文字列結合SQL（UNION/コメント構文が有効）
+- **フォーム値改ざん**: `/purchase/:productId` の `unit_price_yen` / `total_yen` を改ざんして送信
+- **CSRF**:
+  - Attacker の `/` でコメント投稿を偽装
+  - Attacker の `/auto-purchase` で購入リクエストを自動送信
 
 詳しい手順は起動後に画面内の「Hands-on」リンクを参照してください（Shop側に手順を表示します）。
 


### PR DESCRIPTION
Add detailed explanations for setup, initial data, environment variables, and hands-on vulnerability flows to the README.

---
<a href="https://cursor.com/background-agent?bcId=bc-96f0a96f-d770-4a2d-bf5f-ca85eba6cfa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96f0a96f-d770-4a2d-bf5f-ca85eba6cfa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `README.md` with clearer setup and usage guidance for the vulnerable shop and attacker services.
> 
> - **構成/Overview**: Adds roles of `Shop` (Express/EJS/SQLite) and `Attacker` site
> - **起動/停止**: Notes `docker compose down` for stopping
> - **初期データ**: Documents reset behavior and seed users/products
> - **環境変数**: Lists `Shop` (`PORT`, `SESSION_SECRET`, `DATABASE_PATH`, `ATTACKER_URL`) and `Attacker` (`PORT`, `TARGET_BASE`) defaults
> - **体験導線**: Details vulnerable flows with concrete routes/params for XSS (search/comments), SQLi (`/login`, `/search?q`), form tampering (`/purchase/:productId`), and CSRF (attacker `/`, `/auto-purchase`)
> 
> No application code changes; documentation-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9bd124e93e8b0f65eaa2fb7355d88daeb2da952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->