### PR TITLE
feat: セッションCookieにhttpOnly: falseを設定（XSS体験用）

### DIFF
--- a/apps/shop/src/server.js
+++ b/apps/shop/src/server.js
@@ -113,7 +113,9 @@ app.use(
     saveUninitialized: false,
     cookie: {
       // CSRF体験が確実にできるよう、GETで購入できる学習用エンドポイントも別途用意する
-      sameSite: "lax"
+      sameSite: "lax",
+      // XSS体験用：JavaScriptからセッションIDを読めるようにする（本番では true 推奨）
+      httpOnly: false
     }
   })
 );


### PR DESCRIPTION
## 概要
XSSハンズオンの体験が確実にできるよう、セッションCookieの `httpOnly` を `false` に設定しました。

## 変更内容
- `apps/shop/src/server.js`: セッションCookieのオプションに `httpOnly: false` を追加
- JavaScriptからセッションID（`connect.sid`）を読み取れるようになり、XSSでセッション乗っ取りのデモが可能になります

## 注意
- **本番環境では `httpOnly: true` を推奨**する旨をコメントで明記しています
- この変更は脆弱性体験用の学習アプリ向けの意図的な設定です

Made with [Cursor](https://cursor.com)