### PR TITLE
Add shop image-based directory traversal hands-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ docker compose up
 - `SESSION_SECRET`（既定: dev-secret）
 - `DATABASE_PATH`（既定: `/data/shop.db`）
 - `ATTACKER_URL`（既定: `http://localhost:9000`。Hands-onページのリンク先に利用）
+- `FILES_ROOT`（既定: `/app/files`。学習用の添付画像パスの基準ディレクトリ）
 
 ### Attacker
 
@@ -59,11 +60,22 @@ docker compose up
   - `/login` のユーザー名/パスワードが文字列結合SQL
   - `/search` の `q` が文字列結合SQL（UNION/コメント構文が有効）
 - **フォーム値改ざん**: `/purchase/:productId` の `unit_price_yen` / `total_yen` を改ざんして送信
+- **ディレクトリ・トラバーサル**:
+  - `/products/:id` のコメントに保存した添付画像パスを `/comment-images/:commentId` が未検証で参照
+  - `../src/server.js` のような値で、想定外のファイルを読み出せる
 - **CSRF**:
   - Attacker の `/` でコメント投稿を偽装
   - Attacker の `/auto-purchase` で購入リクエストを自動送信
 
 詳しい手順は起動後に画面内の「Hands-on」リンクを参照してください（Shop側に手順を表示します）。
+
+## ディレクトリ・トラバーサルの再現手順
+
+1. `alice / password123` でログインし、`/products/1` を開く
+2. コメント欄の「添付画像パス（学習用）」に `samples/coffee.svg` を入れて投稿し、通常の画像表示を確認する
+3. 続けて `../src/server.js` を入れて投稿する
+4. 投稿されたコメントの「添付ファイルを開く」を押す
+5. 本来は画像だけが表示される想定なのに、Shop のサーバーソースが読めることを確認する
 
 ## 注意
 

--- a/apps/shop/files/samples/coffee.svg
+++ b/apps/shop/files/samples/coffee.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120">
+  <rect width="240" height="120" rx="18" fill="#f5efe6" />
+  <circle cx="78" cy="60" r="26" fill="#7c4a21" />
+  <rect x="108" y="38" width="68" height="44" rx="10" fill="#9a6a3a" />
+  <text x="20" y="106" font-family="sans-serif" font-size="20" fill="#5b3718">Coffee Sample</text>
+</svg>

--- a/apps/shop/package.json
+++ b/apps/shop/package.json
@@ -6,7 +6,8 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node src/server.js"
+    "dev": "node src/server.js",
+    "test": "node test/server.test.js"
   },
   "dependencies": {
     "better-sqlite3": "11.6.0",

--- a/apps/shop/public/styles.css
+++ b/apps/shop/public/styles.css
@@ -360,3 +360,10 @@ pre {
   color: var(--muted);
   font-size: 13px;
 }
+
+.comment-image {
+  max-width: min(100%, 320px);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fafc;
+}

--- a/apps/shop/src/server.js
+++ b/apps/shop/src/server.js
@@ -10,6 +10,8 @@ const DEFAULT_SESSION_SECRET = process.env.SESSION_SECRET || "dev-secret";
 const DEFAULT_DATABASE_PATH =
   process.env.DATABASE_PATH || path.join(__dirname, "..", "data", "shop.db");
 const DEFAULT_ATTACKER_URL = process.env.ATTACKER_URL || "http://localhost:5000";
+const DEFAULT_FILES_ROOT =
+  process.env.FILES_ROOT || path.join(__dirname, "..", "files");
 
 function openDb(databasePath) {
   const dir = path.dirname(databasePath);
@@ -52,6 +54,7 @@ function initDb(db) {
       product_id INTEGER NOT NULL,
       user_id INTEGER NOT NULL,
       body TEXT NOT NULL,
+      image_path TEXT,
       created_at TEXT NOT NULL,
       FOREIGN KEY(product_id) REFERENCES products(id),
       FOREIGN KEY(user_id) REFERENCES users(id)
@@ -95,18 +98,26 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
 function createApp(options) {
   const config = Object.assign(
     {
       sessionSecret: DEFAULT_SESSION_SECRET,
       databasePath: DEFAULT_DATABASE_PATH,
       attackerUrl: DEFAULT_ATTACKER_URL,
+      filesRoot: DEFAULT_FILES_ROOT,
       logger: morgan("dev")
     },
     options || {}
   );
 
   const db = config.db || openDb(config.databasePath);
+  ensureDir(config.filesRoot);
   if (!config.skipInitDb) {
     initDb(db);
   }
@@ -231,7 +242,7 @@ function createApp(options) {
     const comments = db
       .prepare(
         `
-        SELECT c.id, c.body, c.created_at, u.username
+        SELECT c.id, c.body, c.image_path, c.created_at, u.username
         FROM comments c
         JOIN users u ON u.id = c.user_id
         WHERE c.product_id = ?
@@ -256,11 +267,29 @@ function createApp(options) {
     }
 
     const body = req.body.body || "";
+    const imagePath = req.body.image_path || "";
     db.prepare(
-      "INSERT INTO comments (product_id, user_id, body, created_at) VALUES (?, ?, ?, ?)"
-    ).run(product.id, req.session.userId, body, nowIso());
+      "INSERT INTO comments (product_id, user_id, body, image_path, created_at) VALUES (?, ?, ?, ?, ?)"
+    ).run(product.id, req.session.userId, body, imagePath, nowIso());
 
     res.redirect("/products/" + product.id);
+  });
+
+  app.get("/comment-images/:commentId", (req, res) => {
+    const comment = db
+      .prepare("SELECT id, image_path FROM comments WHERE id = ?")
+      .get(req.params.commentId);
+    if (!comment || !comment.image_path) {
+      return res.status(404).send("Not Found");
+    }
+
+    // Directory traversal vulnerability: stored path is trusted as-is.
+    const filePath = path.join(config.filesRoot, comment.image_path);
+    res.sendFile(filePath, (error) => {
+      if (error && !res.headersSent) {
+        res.status(error.statusCode || 404).send("Not Found");
+      }
+    });
   });
 
   app.get("/search", (req, res) => {

--- a/apps/shop/src/server.js
+++ b/apps/shop/src/server.js
@@ -5,25 +5,25 @@ const session = require("express-session");
 const morgan = require("morgan");
 const Database = require("better-sqlite3");
 
-const PORT = Number(process.env.PORT || 8000);
-const SESSION_SECRET = process.env.SESSION_SECRET || "dev-secret";
-const DATABASE_PATH =
+const DEFAULT_PORT = Number(process.env.PORT || 8000);
+const DEFAULT_SESSION_SECRET = process.env.SESSION_SECRET || "dev-secret";
+const DEFAULT_DATABASE_PATH =
   process.env.DATABASE_PATH || path.join(__dirname, "..", "data", "shop.db");
-const ATTACKER_URL = process.env.ATTACKER_URL || "http://localhost:5000";
+const DEFAULT_ATTACKER_URL = process.env.ATTACKER_URL || "http://localhost:5000";
 
-function openDb() {
-  const dir = path.dirname(DATABASE_PATH);
+function openDb(databasePath) {
+  const dir = path.dirname(databasePath);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-  const db = new Database(DATABASE_PATH);
+  const db = new Database(databasePath);
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
   return db;
 }
 
 function initDb(db) {
-  // スキーマ変更があっても再現性を優先し、毎回作り直す
+  // Rebuild for reproducible hands-on state on each process boot.
   db.exec(`
     DROP TABLE IF EXISTS orders;
     DROP TABLE IF EXISTS comments;
@@ -95,256 +95,316 @@ function nowIso() {
   return new Date().toISOString();
 }
 
-const db = openDb();
-initDb(db);
+function createApp(options) {
+  const config = Object.assign(
+    {
+      sessionSecret: DEFAULT_SESSION_SECRET,
+      databasePath: DEFAULT_DATABASE_PATH,
+      attackerUrl: DEFAULT_ATTACKER_URL,
+      logger: morgan("dev")
+    },
+    options || {}
+  );
 
-const app = express();
-app.set("view engine", "ejs");
-app.set("views", path.join(__dirname, "..", "views"));
+  const db = config.db || openDb(config.databasePath);
+  if (!config.skipInitDb) {
+    initDb(db);
+  }
 
-app.use(morgan("dev"));
-app.use(express.urlencoded({ extended: true }));
-app.use(express.static(path.join(__dirname, "..", "public")));
+  const app = express();
+  app.set("view engine", "ejs");
+  app.set("views", path.join(__dirname, "..", "views"));
 
-app.use(
-  session({
-    secret: SESSION_SECRET,
-    resave: false,
-    saveUninitialized: false,
-    cookie: {
-      // CSRF体験が確実にできるよう、GETで購入できる学習用エンドポイントも別途用意する
-      sameSite: "lax",
-      // XSS体験用：JavaScriptからセッションIDを読めるようにする（本番では true 推奨）
-      httpOnly: false
+  if (config.logger) {
+    app.use(config.logger);
+  }
+  app.use(express.urlencoded({ extended: true }));
+  app.use(express.static(path.join(__dirname, "..", "public")));
+
+  app.use(
+    session({
+      secret: config.sessionSecret,
+      resave: false,
+      saveUninitialized: false,
+      cookie: {
+        sameSite: "lax",
+        httpOnly: false
+      }
+    })
+  );
+
+  app.use((req, res, next) => {
+    let currentUser = null;
+    if (req.session.userId) {
+      currentUser = db
+        .prepare("SELECT id, username, email FROM users WHERE id = ?")
+        .get(req.session.userId);
     }
-  })
-);
-
-app.use((req, res, next) => {
-  let currentUser = null;
-  if (req.session.userId) {
-    currentUser = db
-      .prepare("SELECT id, username, email FROM users WHERE id = ?")
-      .get(req.session.userId);
-  }
-  res.locals.currentUser = currentUser;
-  next();
-});
-
-function requireLogin(req, res, next) {
-  if (!req.session.userId) {
-    return res.redirect("/login");
-  }
-  next();
-}
-
-app.get("/", (req, res) => {
-  res.render("home", { currentUser: res.locals.currentUser });
-});
-
-app.get("/hands-on", (req, res) => {
-  res.render("hands_on", { currentUser: res.locals.currentUser, attackerUrl: ATTACKER_URL + "/csrf" });
-});
-
-app.get("/register", (req, res) => {
-  res.render("register", { error: null, currentUser: res.locals.currentUser });
-});
-
-app.post("/register", (req, res) => {
-  const { username, password, email } = req.body;
-  try {
-    db.prepare(
-      "INSERT INTO users (username, password, email, secret_note) VALUES (?, ?, ?, ?)"
-    ).run(username, password, email, `secret_for_${username}`);
-    return res.redirect("/login");
-  } catch (e) {
-    return res
-      .status(400)
-      .render("register", { error: String(e), currentUser: res.locals.currentUser });
-  }
-});
-
-app.get("/login", (req, res) => {
-  res.render("login", { error: null, currentUser: res.locals.currentUser });
-});
-
-app.post("/login", (req, res) => {
-  const { username, password } = req.body;
-
-  // SQLi脆弱性: 文字列結合SQL（意図的）
-  const sql =
-    "SELECT id, username FROM users WHERE username = '" +
-    username +
-    "' AND password = '" +
-    password +
-    "'";
-
-  const user = db.prepare(sql).get();
-  if (!user) {
-    return res
-      .status(401)
-      .render("login", { error: "ログイン失敗（またはSQLiを試してみてください）", currentUser: null });
-  }
-
-  req.session.userId = user.id;
-  return res.redirect("/products");
-});
-
-app.get("/logout", (req, res) => {
-  req.session.destroy(() => {
-    res.redirect("/");
+    res.locals.currentUser = currentUser;
+    next();
   });
-});
 
-app.get("/products", (req, res) => {
-  const products = db.prepare("SELECT * FROM products ORDER BY id").all();
-  res.render("products", { products, currentUser: res.locals.currentUser });
-});
+  function requireLogin(req, res, next) {
+    if (!req.session.userId) {
+      return res.redirect("/login");
+    }
+    next();
+  }
 
-app.get("/products/:id", (req, res) => {
-  const product = db
-    .prepare("SELECT * FROM products WHERE id = ?")
-    .get(req.params.id);
-  if (!product) return res.status(404).send("Not Found");
+  app.get("/", (req, res) => {
+    res.render("home", { currentUser: res.locals.currentUser });
+  });
 
-  const comments = db
-    .prepare(
+  app.get("/hands-on", (req, res) => {
+    res.render("hands_on", {
+      currentUser: res.locals.currentUser,
+      attackerUrl: config.attackerUrl + "/csrf"
+    });
+  });
+
+  app.get("/register", (req, res) => {
+    res.render("register", { error: null, currentUser: res.locals.currentUser });
+  });
+
+  app.post("/register", (req, res) => {
+    const username = req.body.username;
+    const password = req.body.password;
+    const email = req.body.email;
+
+    try {
+      db.prepare(
+        "INSERT INTO users (username, password, email, secret_note) VALUES (?, ?, ?, ?)"
+      ).run(username, password, email, "secret_for_" + username);
+      return res.redirect("/login");
+    } catch (e) {
+      return res
+        .status(400)
+        .render("register", { error: String(e), currentUser: res.locals.currentUser });
+    }
+  });
+
+  app.get("/login", (req, res) => {
+    res.render("login", { error: null, currentUser: res.locals.currentUser });
+  });
+
+  app.post("/login", (req, res) => {
+    const username = req.body.username;
+    const password = req.body.password;
+
+    const sql =
+      "SELECT id, username FROM users WHERE username = '" +
+      username +
+      "' AND password = '" +
+      password +
+      "'";
+
+    const user = db.prepare(sql).get();
+    if (!user) {
+      return res
+        .status(401)
+        .render("login", { error: "ログイン失敗（またはSQLiを試してみてください）", currentUser: null });
+    }
+
+    req.session.userId = user.id;
+    return res.redirect("/products");
+  });
+
+  app.get("/logout", (req, res) => {
+    req.session.destroy(() => {
+      res.redirect("/");
+    });
+  });
+
+  app.get("/products", (req, res) => {
+    const products = db.prepare("SELECT * FROM products ORDER BY id").all();
+    res.render("products", { products: products, currentUser: res.locals.currentUser });
+  });
+
+  app.get("/products/:id", (req, res) => {
+    const product = db
+      .prepare("SELECT * FROM products WHERE id = ?")
+      .get(req.params.id);
+    if (!product) {
+      return res.status(404).send("Not Found");
+    }
+
+    const comments = db
+      .prepare(
+        `
+        SELECT c.id, c.body, c.created_at, u.username
+        FROM comments c
+        JOIN users u ON u.id = c.user_id
+        WHERE c.product_id = ?
+        ORDER BY c.id DESC
       `
-      SELECT c.id, c.body, c.created_at, u.username
-      FROM comments c
-      JOIN users u ON u.id = c.user_id
-      WHERE c.product_id = ?
-      ORDER BY c.id DESC
-    `
-    )
-    .all(product.id);
+      )
+      .all(product.id);
 
-  res.render("product_detail", {
-    product,
-    comments,
-    currentUser: res.locals.currentUser
-  });
-});
-
-app.post("/products/:id/comments", requireLogin, (req, res) => {
-  const product = db
-    .prepare("SELECT * FROM products WHERE id = ?")
-    .get(req.params.id);
-  if (!product) return res.status(404).send("Not Found");
-
-  const body = req.body.body || "";
-  db.prepare(
-    "INSERT INTO comments (product_id, user_id, body, created_at) VALUES (?, ?, ?, ?)"
-  ).run(product.id, req.session.userId, body, nowIso());
-
-  res.redirect(`/products/${product.id}`);
-});
-
-app.get("/search", (req, res) => {
-  const q = req.query.q || "";
-  if (!q) {
-    return res.render("search", {
-      q,
-      results: null,
-      sql: null,
+    res.render("product_detail", {
+      product: product,
+      comments: comments,
       currentUser: res.locals.currentUser
     });
-  }
-
-  // SQLi脆弱性: 文字列結合SQL（意図的）
-  const sql =
-    "SELECT id, name, description, price_yen FROM products WHERE name LIKE '%" +
-    q +
-    "%' OR description LIKE '%" +
-    q +
-    "%' ORDER BY id";
-
-  let results = [];
-  try {
-    results = db.prepare(sql).all();
-  } catch (e) {
-    results = [
-      {
-        id: "ERROR",
-        name: String(e),
-        description: "",
-        price_yen: 0
-      }
-    ];
-  }
-
-  res.render("search", { q, results, sql, currentUser: res.locals.currentUser });
-});
-
-app.get("/purchase/:productId", requireLogin, (req, res) => {
-  const product = db
-    .prepare("SELECT * FROM products WHERE id = ?")
-    .get(req.params.productId);
-  if (!product) return res.status(404).send("Not Found");
-  res.render("purchase", { product, currentUser: res.locals.currentUser });
-});
-
-function createOrderFromParams({ userId, productId, quantity, unitPrice, total, note }) {
-  const created_at = nowIso();
-  const info = db
-    .prepare(
-      `
-      INSERT INTO orders (user_id, product_id, quantity, unit_price_yen, total_yen, note, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `
-    )
-    .run(userId, productId, quantity, unitPrice, total, note || null, created_at);
-
-  return db.prepare("SELECT * FROM orders WHERE id = ?").get(info.lastInsertRowid);
-}
-
-app.post("/purchase", requireLogin, (req, res) => {
-  const productId = Number(req.body.product_id);
-  const product = db.prepare("SELECT * FROM products WHERE id = ?").get(productId);
-  if (!product) return res.status(404).send("Not Found");
-
-  const quantityRaw = parseInt(req.body.quantity, 10);
-  const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? quantityRaw : 1;
-
-  const unitPriceRaw = Number(req.body.unit_price_yen);
-  const unitPrice = Number.isFinite(unitPriceRaw) ? unitPriceRaw : product.price_yen;
-  const totalRaw = Number(req.body.total_yen);
-  const total = Number.isFinite(totalRaw) ? totalRaw : unitPrice * quantity;
-
-  const note = req.body.note || "";
-
-  // Param Tampering 脆弱性: 送信値を信用して保存（意図的）
-  const order = createOrderFromParams({
-    userId: req.session.userId,
-    productId,
-    quantity,
-    unitPrice,
-    total,
-    note
   });
 
-  res.render("order_done", { order, currentUser: res.locals.currentUser });
-});
+  app.post("/products/:id/comments", requireLogin, (req, res) => {
+    const product = db
+      .prepare("SELECT * FROM products WHERE id = ?")
+      .get(req.params.id);
+    if (!product) {
+      return res.status(404).send("Not Found");
+    }
 
-app.get("/orders", requireLogin, (req, res) => {
-  const orders = db
-    .prepare(
+    const body = req.body.body || "";
+    db.prepare(
+      "INSERT INTO comments (product_id, user_id, body, created_at) VALUES (?, ?, ?, ?)"
+    ).run(product.id, req.session.userId, body, nowIso());
+
+    res.redirect("/products/" + product.id);
+  });
+
+  app.get("/search", (req, res) => {
+    const q = req.query.q || "";
+    if (!q) {
+      return res.render("search", {
+        q: q,
+        results: null,
+        sql: null,
+        currentUser: res.locals.currentUser
+      });
+    }
+
+    const sql =
+      "SELECT id, name, description, price_yen FROM products WHERE name LIKE '%" +
+      q +
+      "%' OR description LIKE '%" +
+      q +
+      "%' ORDER BY id";
+
+    let results = [];
+    try {
+      results = db.prepare(sql).all();
+    } catch (e) {
+      results = [
+        {
+          id: "ERROR",
+          name: String(e),
+          description: "",
+          price_yen: 0
+        }
+      ];
+    }
+
+    res.render("search", {
+      q: q,
+      results: results,
+      sql: sql,
+      currentUser: res.locals.currentUser
+    });
+  });
+
+  app.get("/purchase/:productId", requireLogin, (req, res) => {
+    const product = db
+      .prepare("SELECT * FROM products WHERE id = ?")
+      .get(req.params.productId);
+    if (!product) {
+      return res.status(404).send("Not Found");
+    }
+    res.render("purchase", { product: product, currentUser: res.locals.currentUser });
+  });
+
+  function createOrderFromParams(params) {
+    const createdAt = nowIso();
+    const info = db
+      .prepare(
+        `
+        INSERT INTO orders (user_id, product_id, quantity, unit_price_yen, total_yen, note, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
       `
-      SELECT o.*, p.name AS product_name
-      FROM orders o
-      JOIN products p ON p.id = o.product_id
-      WHERE o.user_id = ?
-      ORDER BY o.id DESC
-    `
-    )
-    .all(req.session.userId);
+      )
+      .run(
+        params.userId,
+        params.productId,
+        params.quantity,
+        params.unitPrice,
+        params.total,
+        params.note || null,
+        createdAt
+      );
 
-  res.render("orders", { orders, currentUser: res.locals.currentUser });
-});
+    return db.prepare("SELECT * FROM orders WHERE id = ?").get(info.lastInsertRowid);
+  }
 
-app.listen(PORT, () => {
-  // eslint-disable-next-line no-console
-  console.log(`[shop] listening on http://localhost:${PORT}`);
-  // eslint-disable-next-line no-console
-  console.log(`[shop] db: ${DATABASE_PATH}`);
-});
+  app.post("/purchase", requireLogin, (req, res) => {
+    const productId = Number(req.body.product_id);
+    const product = db.prepare("SELECT * FROM products WHERE id = ?").get(productId);
+    if (!product) {
+      return res.status(404).send("Not Found");
+    }
+
+    const quantityRaw = parseInt(req.body.quantity, 10);
+    const quantity = Number.isFinite(quantityRaw) && quantityRaw > 0 ? quantityRaw : 1;
+
+    const unitPriceRaw = Number(req.body.unit_price_yen);
+    const unitPrice = Number.isFinite(unitPriceRaw) ? unitPriceRaw : product.price_yen;
+    const totalRaw = Number(req.body.total_yen);
+    const total = Number.isFinite(totalRaw) ? totalRaw : unitPrice * quantity;
+    const note = req.body.note || "";
+
+    const order = createOrderFromParams({
+      userId: req.session.userId,
+      productId: productId,
+      quantity: quantity,
+      unitPrice: unitPrice,
+      total: total,
+      note: note
+    });
+
+    res.render("order_done", { order: order, currentUser: res.locals.currentUser });
+  });
+
+  app.get("/orders", requireLogin, (req, res) => {
+    const orders = db
+      .prepare(
+        `
+        SELECT o.*, p.name AS product_name
+        FROM orders o
+        JOIN products p ON p.id = o.product_id
+        WHERE o.user_id = ?
+        ORDER BY o.id DESC
+      `
+      )
+      .all(req.session.userId);
+
+    res.render("orders", { orders: orders, currentUser: res.locals.currentUser });
+  });
+
+  app.locals.db = db;
+  app.locals.config = config;
+
+  return { app: app, db: db };
+}
+
+function startServer(options) {
+  const config = Object.assign({ port: DEFAULT_PORT, host: undefined }, options || {});
+  const created = createApp(config);
+  const server = created.app.listen(config.port, config.host, () => {
+    // eslint-disable-next-line no-console
+    console.log("[shop] listening on http://localhost:" + config.port);
+    // eslint-disable-next-line no-console
+    console.log("[shop] db: " + config.databasePath);
+  });
+  return { app: created.app, db: created.db, server: server };
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = {
+  createApp: createApp,
+  initDb: initDb,
+  nowIso: nowIso,
+  openDb: openDb,
+  startServer: startServer
+};

--- a/apps/shop/test/fixtures/traversal-secret.txt
+++ b/apps/shop/test/fixtures/traversal-secret.txt
@@ -1,0 +1,1 @@
+directory traversal fixture

--- a/apps/shop/test/helpers/http.js
+++ b/apps/shop/test/helpers/http.js
@@ -1,0 +1,52 @@
+const http = require("http");
+const querystring = require("querystring");
+
+function sendRequest(server, options) {
+  return new Promise((resolve, reject) => {
+    const address = server.address();
+    const headers = Object.assign({}, options.headers || {});
+    let body = options.body || null;
+
+    if (body && !Buffer.isBuffer(body) && typeof body !== "string") {
+      body = querystring.stringify(body);
+      if (!headers["content-type"]) {
+        headers["content-type"] = "application/x-www-form-urlencoded";
+      }
+    }
+
+    if (body) {
+      headers["content-length"] = Buffer.byteLength(body);
+    }
+
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        method: options.method || "GET",
+        path: options.path,
+        headers: headers
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          resolve({
+            statusCode: response.statusCode,
+            headers: response.headers,
+            body: Buffer.concat(chunks)
+          });
+        });
+      }
+    );
+
+    request.on("error", reject);
+    if (body) {
+      request.write(body);
+    }
+    request.end();
+  });
+}
+
+module.exports = {
+  sendRequest: sendRequest
+};

--- a/apps/shop/test/server.test.js
+++ b/apps/shop/test/server.test.js
@@ -111,7 +111,7 @@ async function run() {
       },
       body: {
         body: "read source",
-        image_path: "../../src/server.js"
+        image_path: "../src/server.js"
       }
     });
     assert.strictEqual(traversalResponse.statusCode, 302);
@@ -147,6 +147,18 @@ async function run() {
     assert.strictEqual(xssResponse.statusCode, 200);
     assert.notStrictEqual(
       xssResponse.body.indexOf(Buffer.from("<script>alert('xss')</script>")),
+      -1
+    );
+
+    const handsOnResponse = await sendRequest(started.server, {
+      path: "/hands-on",
+      headers: {
+        cookie: cookie
+      }
+    });
+    assert.strictEqual(handsOnResponse.statusCode, 200);
+    assert.notStrictEqual(
+      handsOnResponse.body.indexOf(Buffer.from("体験⑤ ディレクトリ・トラバーサル")),
       -1
     );
   } finally {

--- a/apps/shop/test/server.test.js
+++ b/apps/shop/test/server.test.js
@@ -1,0 +1,99 @@
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { startServer } = require("../src/server");
+const { sendRequest } = require("./helpers/http");
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vulnerable-shop-test-"));
+}
+
+function waitForListening(server) {
+  return new Promise((resolve, reject) => {
+    if (server.listening) {
+      resolve();
+      return;
+    }
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+}
+
+async function run() {
+  const tempRoot = createTempDir();
+  const databasePath = path.join(tempRoot, "data", "shop.db");
+  const filesDir = path.join(tempRoot, "files");
+
+  fs.mkdirSync(filesDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tempRoot, "traversal-secret.txt"),
+    "directory traversal fixture\n",
+    "utf8"
+  );
+
+  const started = startServer({
+    attackerUrl: "http://localhost:9000",
+    databasePath: databasePath,
+    logger: null,
+    port: 0,
+    host: "127.0.0.1"
+  });
+  await waitForListening(started.server);
+
+  try {
+    const homeResponse = await sendRequest(started.server, { path: "/" });
+    assert.strictEqual(homeResponse.statusCode, 200);
+    assert.notStrictEqual(homeResponse.body.indexOf(Buffer.from("Hands-on")), -1);
+
+    const loginResponse = await sendRequest(started.server, {
+      method: "POST",
+      path: "/login",
+      body: {
+        username: "alice",
+        password: "password123"
+      }
+    });
+    assert.strictEqual(loginResponse.statusCode, 302);
+    assert.strictEqual(loginResponse.headers.location, "/products");
+    assert.ok(loginResponse.headers["set-cookie"]);
+
+    const cookie = loginResponse.headers["set-cookie"][0].split(";")[0];
+    const commentResponse = await sendRequest(started.server, {
+      method: "POST",
+      path: "/products/1/comments",
+      headers: {
+        cookie: cookie
+      },
+      body: {
+        body: "<script>alert('xss')</script>"
+      }
+    });
+    assert.strictEqual(commentResponse.statusCode, 302);
+
+    const productResponse = await sendRequest(started.server, {
+      path: "/products/1",
+      headers: {
+        cookie: cookie
+      }
+    });
+    assert.strictEqual(productResponse.statusCode, 200);
+    assert.notStrictEqual(
+      productResponse.body.indexOf(Buffer.from("<script>alert('xss')</script>")),
+      -1
+    );
+  } finally {
+    started.server.close();
+    started.db.close();
+  }
+}
+
+run()
+  .then(() => {
+    process.stdout.write("ok\n");
+  })
+  .catch((error) => {
+    process.stderr.write(String(error && error.stack ? error.stack : error) + "\n");
+    process.exit(1);
+  });

--- a/apps/shop/test/server.test.js
+++ b/apps/shop/test/server.test.js
@@ -25,17 +25,26 @@ async function run() {
   const tempRoot = createTempDir();
   const databasePath = path.join(tempRoot, "data", "shop.db");
   const filesDir = path.join(tempRoot, "files");
+  const sampleDir = path.join(filesDir, "samples");
+  const srcDir = path.join(tempRoot, "src");
 
-  fs.mkdirSync(filesDir, { recursive: true });
+  fs.mkdirSync(sampleDir, { recursive: true });
+  fs.mkdirSync(srcDir, { recursive: true });
   fs.writeFileSync(
-    path.join(tempRoot, "traversal-secret.txt"),
-    "directory traversal fixture\n",
+    path.join(sampleDir, "coffee.svg"),
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40"><text x="8" y="24">coffee</text></svg>\n',
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(srcDir, "server.js"),
+    "sensitive server source fixture\n",
     "utf8"
   );
 
   const started = startServer({
     attackerUrl: "http://localhost:9000",
     databasePath: databasePath,
+    filesRoot: filesDir,
     logger: null,
     port: 0,
     host: "127.0.0.1"
@@ -60,17 +69,18 @@ async function run() {
     assert.ok(loginResponse.headers["set-cookie"]);
 
     const cookie = loginResponse.headers["set-cookie"][0].split(";")[0];
-    const commentResponse = await sendRequest(started.server, {
+    const imageCommentResponse = await sendRequest(started.server, {
       method: "POST",
       path: "/products/1/comments",
       headers: {
         cookie: cookie
       },
       body: {
-        body: "<script>alert('xss')</script>"
+        body: "sample image",
+        image_path: "samples/coffee.svg"
       }
     });
-    assert.strictEqual(commentResponse.statusCode, 302);
+    assert.strictEqual(imageCommentResponse.statusCode, 302);
 
     const productResponse = await sendRequest(started.server, {
       path: "/products/1",
@@ -80,7 +90,63 @@ async function run() {
     });
     assert.strictEqual(productResponse.statusCode, 200);
     assert.notStrictEqual(
-      productResponse.body.indexOf(Buffer.from("<script>alert('xss')</script>")),
+      productResponse.body.indexOf(Buffer.from("/comment-images/1")),
+      -1
+    );
+
+    const imageResponse = await sendRequest(started.server, {
+      path: "/comment-images/1"
+    });
+    assert.strictEqual(imageResponse.statusCode, 200);
+    assert.notStrictEqual(
+      imageResponse.body.indexOf(Buffer.from("<svg")),
+      -1
+    );
+
+    const traversalResponse = await sendRequest(started.server, {
+      method: "POST",
+      path: "/products/1/comments",
+      headers: {
+        cookie: cookie
+      },
+      body: {
+        body: "read source",
+        image_path: "../../src/server.js"
+      }
+    });
+    assert.strictEqual(traversalResponse.statusCode, 302);
+
+    const leakedResponse = await sendRequest(started.server, {
+      path: "/comment-images/2"
+    });
+    assert.strictEqual(leakedResponse.statusCode, 200);
+    assert.notStrictEqual(
+      leakedResponse.body.indexOf(Buffer.from("sensitive server source fixture")),
+      -1
+    );
+
+    const xssCommentResponse = await sendRequest(started.server, {
+      method: "POST",
+      path: "/products/1/comments",
+      headers: {
+        cookie: cookie
+      },
+      body: {
+        body: "<script>alert('xss')</script>",
+        image_path: ""
+      }
+    });
+    assert.strictEqual(xssCommentResponse.statusCode, 302);
+
+    const xssResponse = await sendRequest(started.server, {
+      path: "/products/1",
+      headers: {
+        cookie: cookie
+      }
+    });
+    assert.strictEqual(xssResponse.statusCode, 200);
+    assert.notStrictEqual(
+      xssResponse.body.indexOf(Buffer.from("<script>alert('xss')</script>")),
       -1
     );
   } finally {

--- a/apps/shop/views/hands_on.ejs
+++ b/apps/shop/views/hands_on.ejs
@@ -83,6 +83,21 @@
     </ol>
     <p class="muted">原因: リクエストが「正しい画面から送られたか」をサーバーが検証していない</p>
   </div>
+
+  <div class="card stack">
+    <div class="section-title">
+      <span class="pill">Traversal</span>
+      <h3 style="margin: 0;">体験⑤ ディレクトリ・トラバーサル</h3>
+    </div>
+    <ol>
+      <li><a href="/login">ログイン</a>（alice / password123）して<a href="/products/1">商品詳細</a>を開く</li>
+      <li>コメント欄の「添付画像パス（学習用）」に <code>samples/coffee.svg</code> を入れて投稿し、通常の画像表示を確認する</li>
+      <li>続けて <code>../src/server.js</code> を入れて投稿する</li>
+      <li>投稿されたコメントの「添付ファイルを開く」をクリックする</li>
+      <li>本来画像しか見えないはずの導線で、サーバーソースが読めることを確認する</li>
+    </ol>
+    <p class="muted">原因: 添付画像パスをサーバーが信用し、許可ディレクトリ外への移動を防いでいない</p>
+  </div>
 </div>
 
 <%- include("partials/footer") %>

--- a/apps/shop/views/product_detail.ejs
+++ b/apps/shop/views/product_detail.ejs
@@ -34,6 +34,11 @@
         <label>コメント本文</label>
         <textarea name="body" rows="3" placeholder="<script>alert(1)</script>"></textarea>
       </div>
+      <div class="form-field">
+        <label>添付画像パス（学習用）</label>
+        <input name="image_path" placeholder="samples/coffee.svg または ../src/server.js" />
+        <div class="muted">画像として表示するファイルパスをそのまま保存します。</div>
+      </div>
       <button type="submit" class="btn btn-primary">投稿</button>
     </form>
   <% } %>
@@ -42,6 +47,15 @@
   <% comments.forEach((c) => { %>
     <div class="card stack">
       <div class="meta"><%= c.created_at %> / <strong><%= c.username %></strong></div>
+      <% if (c.image_path) { %>
+        <div class="stack">
+          <div class="meta">添付画像パス: <code><%= c.image_path %></code></div>
+          <div class="actions">
+            <a class="btn btn-link" href="/comment-images/<%= c.id %>" target="_blank" rel="noreferrer">添付ファイルを開く</a>
+          </div>
+          <img class="comment-image" src="/comment-images/<%= c.id %>" alt="comment attachment <%= c.id %>" />
+        </div>
+      <% } %>
       <div>
         <!-- XSS脆弱性: 無エスケープ -->
         <%- c.body %>


### PR DESCRIPTION
## Summary
- add a shop-side image attachment path flow that intentionally allows directory traversal via comment attachments
- refactor the shop server for HTTP-level testability and add regression coverage for XSS, image serving, traversal, and the hands-on guide
- document the new scenario with an investigation report, implementation plan, checklist, README updates, and a new hands-on card

## Testing
- npm test

## Review
- Self-review completed with no actionable findings; residual risk is that the teaching flow uses image path input rather than true multipart upload, which is recorded in the checklist as an intentional plan change.